### PR TITLE
`serde` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,14 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Clippy: all features"
           args: --workspace --all-features --all-targets -- -D warnings
+      - name: Clippy (no features)
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Clippy: no features"
+          args: --workspace --no-default-features --all-targets -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets
+          args: --workspace --all-features --all-targets
       - name: Run doc tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --doc
+          args: --workspace --all-features --doc
 
   build:
     runs-on: ubuntu-latest
@@ -70,29 +70,29 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets -- -D warnings
+          args: --workspace --all-features --all-targets -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets
+          args: --workspace --all-features --all-targets
       - name: Run doc tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --doc
+          args: --workspace --all-features --doc
 
       - name: Run voting (ristretto)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p elastic-elgamal --example voting
+          args: -p elastic-elgamal --all-features --example voting
       - name: Run voting (k256)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p elastic-elgamal --example voting -- k256
+          args: -p elastic-elgamal --all-features --example voting -- k256
 
   document:
     if: github.event_name == 'push'
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build docs
         run: |
-          cargo clean --doc && cargo rustdoc -p elastic-elgamal
+          cargo clean --doc && cargo rustdoc -p elastic-elgamal --all-features
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ elliptic-curve = "0.10.1"
 rand_core = { version = "0.6.2", features = ["std"] }
 zeroize = { version = "1.3.0", default-features = false }
 
+# Enables `Serialize` / `Deserialize` implementation for most types in the crate.
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Private dependencies (not exposed via public APIs).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ zeroize = { version = "1.3.0", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Private dependencies (not exposed via public APIs).
-base64 = "0.13.0"
+base64ct = { version = "1.0", features = ["alloc"] }
 byteorder = "1.4.3"
 ff = { version = "0.10.0", default-features = false }
 merlin = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ elliptic-curve = "0.10.1"
 rand_core = { version = "0.6.2", features = ["std"] }
 zeroize = { version = "1.3.0", default-features = false }
 
+serde = { version = "1.0", features = ["derive"], optional = true }
+
 # Private dependencies (not exposed via public APIs).
+base64 = "0.13.0"
 byteorder = "1.4.3"
 ff = { version = "0.10.0", default-features = false }
-hex = "0.4.3"
 merlin = "3.0.0"
 rand_chacha = "0.3.1"
 smallvec = "1.6.1"
@@ -30,6 +32,7 @@ subtle = "2.4.0"
 criterion = "0.3.4"
 k256 = { version = "0.9.1", default-features = false, features = ["arithmetic", "std", "zeroize"] }
 rand = "0.8.3"
+serde_json = "1.0"
 version-sync = "0.9.2"
 
 [[bench]]
@@ -41,6 +44,11 @@ harness = false
 name = "sharing"
 path = "benches/sharing.rs"
 harness = false
+
+[[example]]
+name = "voting"
+path = "examples/voting.rs"
+required-features = ["serde"]
 
 # Speed up `k256` arithmetic.
 [profile.dev.package.k256]

--- a/examples/voting.rs
+++ b/examples/voting.rs
@@ -37,6 +37,10 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
     let talliers: Vec<_> = (0..params.shares)
         .map(|i| StartingParticipant::<G>::new(params, i, rng))
         .collect();
+    println!(
+        "Talliers: {}",
+        serde_json::to_string_pretty(&talliers).unwrap()
+    );
 
     // Public tallier parameters together with proofs may be shared publicly
     // (e.g., on a blockchain).
@@ -47,6 +51,11 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
             .add_participant(i, poly.to_vec(), proof)
             .unwrap();
     }
+    println!(
+        "Partial public key set after receiving all commitments: {}",
+        serde_json::to_string_pretty(&partial_info).unwrap()
+    );
+
     let key_set = partial_info.complete().unwrap();
 
     println!(
@@ -58,6 +67,10 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
         .into_iter()
         .map(|tallier| tallier.finalize_key_set(&partial_info).unwrap())
         .collect();
+    println!(
+        "Talliers after finalizing key set: {}",
+        serde_json::to_string_pretty(&talliers).unwrap()
+    );
 
     // Then, talliers exchange private shares with each other.
     // This is the only private / non-auditable part of the protocol, although it can be made
@@ -75,6 +88,10 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
         .into_iter()
         .map(|tallier| tallier.complete())
         .collect();
+    println!(
+        "Active talliers: {}",
+        serde_json::to_string_pretty(&talliers).unwrap()
+    );
     (key_set, talliers)
 }
 

--- a/examples/voting.rs
+++ b/examples/voting.rs
@@ -65,7 +65,7 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
     for i in 0..talliers.len() {
         for j in 0..talliers.len() {
             if j != i {
-                let message = talliers[i].message(j);
+                let message = talliers[i].message(j).clone();
                 talliers[j].process_message(i, message).unwrap();
             }
         }

--- a/examples/voting.rs
+++ b/examples/voting.rs
@@ -9,7 +9,7 @@
 use rand::{seq::IteratorRandom, thread_rng, Rng};
 use rand_core::{CryptoRng, RngCore};
 
-use std::{collections::HashMap, env, iter::FromIterator};
+use std::env;
 
 use elastic_elgamal::{
     group::{Curve25519Subgroup, Generic, Group, Ristretto},
@@ -30,20 +30,6 @@ const TALLIER_PARAMS: Params = Params {
     threshold: 3,
 };
 
-fn dump_group_info<G: Group>(info: &PublicKeySet<G>) {
-    println!(
-        "Shared public key: {}",
-        hex::encode(info.shared_key().as_bytes())
-    );
-    for (i, key) in info.participant_keys().iter().enumerate() {
-        println!(
-            "Participant #{} key: {}",
-            i + 1,
-            hex::encode(key.as_bytes())
-        );
-    }
-}
-
 fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
     params: Params,
     rng: &mut R,
@@ -61,10 +47,12 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
             .add_participant(i, poly.to_vec(), proof)
             .unwrap();
     }
-    let group = partial_info.complete().unwrap();
+    let key_set = partial_info.complete().unwrap();
 
-    println!("Threshold encryption params:");
-    dump_group_info(&group);
+    println!(
+        "Threshold encryption params: {}",
+        serde_json::to_string_pretty(&key_set).unwrap()
+    );
 
     let mut talliers: Vec<_> = talliers
         .into_iter()
@@ -87,7 +75,7 @@ fn initialize_talliers<G: Group, R: CryptoRng + RngCore>(
         .into_iter()
         .map(|tallier| tallier.complete())
         .collect();
-    (group, talliers)
+    (key_set, talliers)
 }
 
 fn vote<G: Group>() {
@@ -107,22 +95,7 @@ fn vote<G: Group>() {
             .shared_key()
             .encrypt_choice(OPTIONS_COUNT, choice, &mut rng);
 
-        println!(
-            "Encrypted choice variants: {:#?}",
-            choice
-                .variants_unchecked()
-                .iter()
-                .map(|variant| hex::encode(&variant.to_bytes()[..]))
-                .collect::<Vec<_>>()
-        );
-        println!(
-            "Range proof: {}",
-            hex::encode(&choice.range_proof().to_bytes())
-        );
-        println!(
-            "Sum proof: {}",
-            hex::encode(&choice.sum_proof().to_bytes()[..])
-        );
+        println!("Choice: {}", serde_json::to_string_pretty(&choice).unwrap());
 
         let variants = key_set.shared_key().verify_choice(&choice).unwrap();
         for (i, &variant) in variants.iter().enumerate() {
@@ -131,11 +104,8 @@ fn vote<G: Group>() {
     }
 
     println!(
-        "\nCumulative choice variants: {:#?}",
-        encrypted_totals
-            .iter()
-            .map(|variant| hex::encode(&variant.to_bytes()[..]))
-            .collect::<Vec<_>>()
+        "\nCumulative choice variants: {}",
+        serde_json::to_string_pretty(&encrypted_totals).unwrap()
     );
 
     // After polling, talliers submit decryption shares together with a proof of their correctness.
@@ -153,16 +123,18 @@ fn vote<G: Group>() {
             .map(|(j, tallier)| (j, tallier.decrypt_share(variant_totals, &mut rng)))
             .map(|(j, (share, proof))| {
                 let share = share.to_bytes(); // Emulate transfer via network
+                let candidate_share = CandidateShare::from_bytes(&share).unwrap();
+                let share_with_proof = serde_json::json!({
+                    "share": &candidate_share,
+                    "proof": &proof,
+                });
+
                 println!(
-                    "Share from tallier #{}: {:#?}",
+                    "Share from tallier #{}: {}",
                     j + 1,
-                    HashMap::<_, _>::from_iter(vec![
-                        ("decryption", hex::encode(&share)),
-                        ("proof", hex::encode(&proof.to_bytes()[..])),
-                    ])
+                    serde_json::to_string_pretty(&share_with_proof).unwrap()
                 );
 
-                let candidate_share = CandidateShare::from_bytes(&share).unwrap();
                 let share = key_set
                     .verify_share(candidate_share, variant_totals, j, &proof)
                     .unwrap();

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -7,13 +7,13 @@ use serde::{Deserialize, Serialize};
 
 use std::{collections::HashMap, fmt, marker::PhantomData, ops};
 
+#[cfg(feature = "serde")]
+use crate::serde::ElementHelper;
 use crate::{
     group::Group,
     proofs::{LogEqualityProof, RingProof, RingProofBuilder},
     PublicKey, SecretKey,
 };
-#[cfg(feature = "serde")]
-use crate::serde::ElementHelper;
 
 /// Ciphertext for ElGamal encryption.
 ///

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -2,6 +2,8 @@
 
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use std::{collections::HashMap, fmt, marker::PhantomData, ops};
 
@@ -10,6 +12,8 @@ use crate::{
     proofs::{LogEqualityProof, RingProof, RingProofBuilder},
     PublicKey, SecretKey,
 };
+#[cfg(feature = "serde")]
+use crate::serde::ElementHelper;
 
 /// Ciphertext for ElGamal encryption.
 ///
@@ -49,8 +53,11 @@ use crate::{
 /// assert!(recipient.public().verify_bool(enc, &proof));
 /// ```
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ciphertext<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ElementHelper::<G>"))]
     pub(crate) random_element: G::Element,
+    #[cfg_attr(feature = "serde", serde(with = "ElementHelper::<G>"))]
     pub(crate) blinded_element: G::Element,
 }
 
@@ -478,6 +485,8 @@ impl<G: Group> ExtendedCiphertext<G> {
 /// }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
 pub struct EncryptedChoice<G: Group> {
     variants: Vec<Ciphertext<G>>,
     range_proof: RingProof<G>,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -83,9 +83,9 @@ impl<G: Group> Ciphertext<G> {
     /// Serializes this ciphertext as two group elements (the random element,
     /// then the blinded value).
     pub fn to_bytes(self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(2 * G::ELEMENT_SIZE);
-        G::serialize_element(&self.random_element, &mut bytes);
-        G::serialize_element(&self.blinded_element, &mut bytes);
+        let mut bytes = vec![0_u8; 2 * G::ELEMENT_SIZE];
+        G::serialize_element(&self.random_element, &mut bytes[..G::ELEMENT_SIZE]);
+        G::serialize_element(&self.blinded_element, &mut bytes[G::ELEMENT_SIZE..]);
         bytes
     }
 }
@@ -388,7 +388,7 @@ impl<G: Group> DiscreteLogTable<G> {
             .filter(|&value| value != 0)
             .map(|i| {
                 let element = G::vartime_mul_generator(&G::Scalar::from(i));
-                let mut bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+                let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
                 G::serialize_element(&element, &mut bytes);
                 (bytes, i)
             })
@@ -408,7 +408,7 @@ impl<G: Group> DiscreteLogTable<G> {
             // for elliptic curves), so we check it separately.
             Some(0)
         } else {
-            let mut bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+            let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
             G::serialize_element(decrypted_element, &mut bytes);
             self.inner.get(&bytes).copied()
         }

--- a/src/group.rs
+++ b/src/group.rs
@@ -5,13 +5,12 @@
 //! (Decisional Diffie–Hellman assumption is considered stronger than both CDH and DL,
 //! so if DDH is believed to hold for a certain group, it should be good to go.)
 //!
-//! Such groups can be applied for ElGamal encryption and other cryptographic protocols from this crate.
+//! Such groups can be applied for ElGamal encryption and other cryptographic protocols
+//! from this crate.
 //!
 //! [DDH]: https://en.wikipedia.org/wiki/Decisional_Diffie%E2%80%93Hellman_assumption
 //! [CDH]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_problem
 //! [DLP]: https://en.wikipedia.org/wiki/Discrete_logarithm
-
-// FIXME: change serialization to use `&mut [u8]`
 
 use rand_chacha::ChaChaRng;
 use rand_core::{CryptoRng, RngCore, SeedableRng};
@@ -82,12 +81,14 @@ pub trait ScalarOps {
         }
     }
 
-    /// Serializes the scalar into a byte buffer.
-    fn serialize_scalar(scalar: &Self::Scalar, output: &mut Vec<u8>);
+    /// Serializes the scalar into the provided `buffer`, which is guaranteed to have length
+    /// [`Self::SCALAR_SIZE`].
+    fn serialize_scalar(scalar: &Self::Scalar, buffer: &mut [u8]);
 
-    /// Deserializes the scalar from the byte buffer. This method returns `None` if the buffer
+    /// Deserializes the scalar from `buffer`, which is guaranteed to have length
+    /// [`Self::SCALAR_SIZE`]. This method returns `None` if the buffer
     /// does not correspond to a representation of a valid scalar.
-    fn deserialize_scalar(bytes: &[u8]) -> Option<Self::Scalar>;
+    fn deserialize_scalar(buffer: &[u8]) -> Option<Self::Scalar>;
 }
 
 /// Helper trait for [`Group`] that describes operations on group elements (i.e., EC points
@@ -115,12 +116,14 @@ pub trait ElementOps: ScalarOps {
     /// Returns the agreed-upon generator of the group.
     fn generator() -> Self::Element;
 
-    /// Serializes `element` into a byte buffer.
-    fn serialize_element(element: &Self::Element, output: &mut Vec<u8>);
-
-    /// Deserializes an element from the byte buffer, which is guaranteed to have length
+    /// Serializes `element` into the provided `buffer`, which is guaranteed to have length
     /// [`Self::ELEMENT_SIZE`].
-    fn deserialize_element(input: &[u8]) -> Option<Self::Element>;
+    fn serialize_element(element: &Self::Element, output: &mut [u8]);
+
+    /// Deserializes an element from `buffer`, which is guaranteed to have length
+    /// [`Self::ELEMENT_SIZE`]. This method returns `None` if the buffer
+    /// does not correspond to a representation of a valid scalar.
+    fn deserialize_element(buffer: &[u8]) -> Option<Self::Element>;
 }
 
 /// Prime-order group in which the discrete log problem and decisional / computational

--- a/src/group.rs
+++ b/src/group.rs
@@ -11,6 +11,8 @@
 //! [CDH]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_problem
 //! [DLP]: https://en.wikipedia.org/wiki/Discrete_logarithm
 
+// FIXME: change serialization to use `&mut [u8]`
+
 use rand_chacha::ChaChaRng;
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 use subtle::{ConditionallySelectable, ConstantTimeEq};

--- a/src/group/curve25519.rs
+++ b/src/group/curve25519.rs
@@ -50,12 +50,12 @@ impl ScalarOps for Curve25519Subgroup {
         Scalar::batch_invert(scalars);
     }
 
-    fn serialize_scalar(scalar: &Self::Scalar, output: &mut Vec<u8>) {
-        output.extend_from_slice(&scalar.to_bytes())
+    fn serialize_scalar(scalar: &Self::Scalar, buffer: &mut [u8]) {
+        buffer.copy_from_slice(&scalar.to_bytes())
     }
 
-    fn deserialize_scalar(bytes: &[u8]) -> Option<Self::Scalar> {
-        let bytes: &[u8; 32] = bytes.try_into().expect("input has incorrect byte size");
+    fn deserialize_scalar(buffer: &[u8]) -> Option<Self::Scalar> {
+        let bytes: &[u8; 32] = buffer.try_into().expect("input has incorrect byte size");
         Scalar::from_canonical_bytes(*bytes)
     }
 }
@@ -77,12 +77,12 @@ impl ElementOps for Curve25519Subgroup {
         ED25519_BASEPOINT_POINT
     }
 
-    fn serialize_element(element: &Self::Element, output: &mut Vec<u8>) {
-        output.extend_from_slice(&element.compress().to_bytes())
+    fn serialize_element(element: &Self::Element, buffer: &mut [u8]) {
+        buffer.copy_from_slice(&element.compress().to_bytes())
     }
 
-    fn deserialize_element(input: &[u8]) -> Option<Self::Element> {
-        CompressedEdwardsY::from_slice(input)
+    fn deserialize_element(buffer: &[u8]) -> Option<Self::Element> {
+        CompressedEdwardsY::from_slice(buffer)
             .decompress()
             .filter(EdwardsPoint::is_torsion_free)
     }

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -39,12 +39,12 @@ impl ScalarOps for Ristretto {
         Scalar::batch_invert(scalars);
     }
 
-    fn serialize_scalar(scalar: &Self::Scalar, output: &mut Vec<u8>) {
-        output.extend_from_slice(&scalar.to_bytes())
+    fn serialize_scalar(scalar: &Self::Scalar, buffer: &mut [u8]) {
+        buffer.copy_from_slice(&scalar.to_bytes())
     }
 
-    fn deserialize_scalar(bytes: &[u8]) -> Option<Self::Scalar> {
-        let bytes: &[u8; 32] = bytes.try_into().expect("input has incorrect byte size");
+    fn deserialize_scalar(buffer: &[u8]) -> Option<Self::Scalar> {
+        let bytes: &[u8; 32] = buffer.try_into().expect("input has incorrect byte size");
         Scalar::from_canonical_bytes(*bytes)
     }
 }
@@ -66,12 +66,12 @@ impl ElementOps for Ristretto {
         RISTRETTO_BASEPOINT_POINT
     }
 
-    fn serialize_element(element: &Self::Element, output: &mut Vec<u8>) {
-        output.extend_from_slice(&element.compress().to_bytes());
+    fn serialize_element(element: &Self::Element, buffer: &mut [u8]) {
+        buffer.copy_from_slice(&element.compress().to_bytes());
     }
 
-    fn deserialize_element(input: &[u8]) -> Option<Self::Element> {
-        CompressedRistretto::from_slice(input).decompress()
+    fn deserialize_element(buffer: &[u8]) -> Option<Self::Element> {
+        CompressedRistretto::from_slice(buffer).decompress()
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,5 +1,6 @@
 //! Cryptographic keys for ElGamal encryption.
 
+use base64ct::{Base64UrlUnpadded, Encoding};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::group::Group;
@@ -105,7 +106,7 @@ impl<G: Group> fmt::Debug for PublicKey<G> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
             .debug_tuple("PublicKey")
-            .field(&base64::encode_config(&self.bytes, base64::URL_SAFE_NO_PAD))
+            .field(&Base64UrlUnpadded::encode_string(&self.bytes))
             .finish()
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -105,7 +105,7 @@ impl<G: Group> fmt::Debug for PublicKey<G> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
             .debug_tuple("PublicKey")
-            .field(&hex::encode(&self.bytes))
+            .field(&base64::encode_config(&self.bytes, base64::URL_SAFE_NO_PAD))
             .finish()
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -145,7 +145,7 @@ impl<G: Group> PublicKey<G> {
     }
 
     pub(crate) fn from_element(element: G::Element) -> Self {
-        let mut element_bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+        let mut element_bytes = vec![0_u8; G::ELEMENT_SIZE];
         G::serialize_element(&element, &mut element_bytes);
         PublicKey {
             element,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ mod encryption;
 pub mod group;
 mod keys;
 mod proofs;
+#[cfg(feature = "serde")]
+mod serde;
 pub mod sharing;
 
 pub use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,23 @@
 //!   the traits specified by the [`elliptic-curve`] crate. For example,
 //!   the secp256k1 curve can be used via the [`k256`] crate.
 //!
+//! # Crate features
+//!
+//! ## `serde`
+//!
+//! *(off by default)*
+//!
+//! Enables [`Serialize`](::serde::Serialize) / [`Deserialize`](::serde::Deserialize)
+//! implementations for most types in the crate.
+//! Group scalars, elements and wrapper key types are serialized to human-readable formats
+//! (JSON, YAML, TOML, etc.) as strings that represent corresponding byte buffers using
+//! base64-url encoding without padding. For binary formats, byte buffers are serialized directly.
+//!
+//! For complex types (e.g., participant states from the [`sharing`] module), self-consistency
+//! checks are **not** performed on deserialization. That is, deserialization of such types
+//! should only be performed from a trusted source or in the presence of additional integrity
+//! checks.
+//!
 //! # Crate naming
 //!
 //! "Elastic" refers to pluggable backends, configurable params for threshold encryption,

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -2,18 +2,18 @@
 
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
-use smallvec::{smallvec, SmallVec};
-use subtle::ConstantTimeEq;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smallvec::{smallvec, SmallVec};
+use subtle::ConstantTimeEq;
 
 use std::{fmt, io};
 
+#[cfg(feature = "serde")]
+use crate::serde::{ScalarHelper, ScalarVec};
 use crate::{
     encryption::ExtendedCiphertext, group::Group, Ciphertext, Keypair, PublicKey, SecretKey,
 };
-#[cfg(feature = "serde")]
-use crate::serde::{ScalarHelper, ScalarVec};
 
 /// Extension trait for Merlin transcripts used in constructing our proofs.
 pub(crate) trait TranscriptForGroup {

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -10,7 +10,7 @@ use subtle::ConstantTimeEq;
 use std::{fmt, io};
 
 #[cfg(feature = "serde")]
-use crate::serde::{ScalarHelper, ScalarVec};
+use crate::serde::{ScalarHelper, VecHelper};
 use crate::{
     encryption::ExtendedCiphertext, group::Group, Ciphertext, Keypair, PublicKey, SecretKey,
 };
@@ -112,7 +112,7 @@ impl TranscriptForGroup for Transcript {
 pub struct ProofOfPossession<G: Group> {
     #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     challenge: G::Scalar,
-    #[cfg_attr(feature = "serde", serde(with = "ScalarVec::<G, 1>"))]
+    #[cfg_attr(feature = "serde", serde(with = "VecHelper::<ScalarHelper<G>, 1>"))]
     responses: Vec<G::Scalar>,
 }
 
@@ -663,7 +663,7 @@ impl<'a, G: Group> Ring<'a, G> {
 pub struct RingProof<G: Group> {
     #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     common_challenge: G::Scalar,
-    #[cfg_attr(feature = "serde", serde(with = "ScalarVec::<G, 2>"))]
+    #[cfg_attr(feature = "serde", serde(with = "VecHelper::<ScalarHelper<G>, 2>"))]
     ring_responses: Vec<G::Scalar>,
 }
 

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -4,12 +4,16 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 use smallvec::{smallvec, SmallVec};
 use subtle::ConstantTimeEq;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use std::{fmt, io};
 
 use crate::{
     encryption::ExtendedCiphertext, group::Group, Ciphertext, Keypair, PublicKey, SecretKey,
 };
+#[cfg(feature = "serde")]
+use crate::serde::{ScalarHelper, ScalarVec};
 
 /// Extension trait for Merlin transcripts used in constructing our proofs.
 pub(crate) trait TranscriptForGroup {
@@ -104,8 +108,11 @@ impl TranscriptForGroup for Transcript {
 /// ```
 // TODO: serialization?
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProofOfPossession<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     challenge: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarVec::<G, 1>"))]
     responses: Vec<G::Scalar>,
 }
 
@@ -260,8 +267,11 @@ impl<G: Group> ProofOfPossession<G> {
 /// [fst]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
 /// [this course]: http://www.cs.au.dk/~ivan/Sigma.pdf
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogEqualityProof<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     challenge: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     response: G::Scalar,
 }
 
@@ -648,9 +658,12 @@ impl<'a, G: Group> Ring<'a, G> {
 /// [ring]: https://link.springer.com/content/pdf/10.1007/3-540-36178-2_26.pdf
 /// [Bulletproofs]: https://crypto.stanford.edu/bulletproofs/
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 // TODO: range proof (think about base etc.)
 pub struct RingProof<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
     common_challenge: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarVec::<G, 2>"))]
     ring_responses: Vec<G::Scalar>,
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,234 @@
+//! (De)serialization utils.
+
+use serde::{
+    de::{Error as DeError, SeqAccess, Unexpected, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use std::{fmt, marker::PhantomData};
+
+use crate::{group::Group, PublicKey};
+
+fn serialize_bytes<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if serializer.is_human_readable() {
+        serializer.serialize_str(&base64::encode_config(value, base64::URL_SAFE_NO_PAD))
+    } else {
+        serializer.serialize_bytes(value)
+    }
+}
+
+fn deserialize_bytes<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Base64Visitor;
+
+    impl Visitor<'_> for Base64Visitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("base64url-encoded data")
+        }
+
+        fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
+            base64::decode_config(value, base64::URL_SAFE_NO_PAD)
+                .map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
+        }
+
+        fn visit_bytes<E: DeError>(self, value: &[u8]) -> Result<Self::Value, E> {
+            Ok(value.to_vec())
+        }
+
+        fn visit_byte_buf<E: DeError>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+    }
+
+    struct BytesVisitor;
+
+    impl<'de> Visitor<'de> for BytesVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("byte buffer")
+        }
+
+        fn visit_bytes<E: DeError>(self, value: &[u8]) -> Result<Self::Value, E> {
+            Ok(value.to_vec())
+        }
+
+        fn visit_byte_buf<E: DeError>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+    }
+
+    if deserializer.is_human_readable() {
+        deserializer.deserialize_str(Base64Visitor)
+    } else {
+        deserializer.deserialize_bytes(BytesVisitor)
+    }
+}
+
+impl<G: Group> Serialize for PublicKey<G> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_bytes(&self.bytes, serializer)
+    }
+}
+
+impl<'de, G: Group> Deserialize<'de> for PublicKey<G> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = deserialize_bytes(deserializer)?;
+        Self::from_bytes(&bytes).map_err(D::Error::custom)
+    }
+}
+
+/// Helper type to deserialize scalars.
+#[derive(Debug)]
+pub struct ScalarHelper<G: Group>(G::Scalar);
+
+impl<G: Group> ScalarHelper<G> {
+    pub fn serialize<S>(scalar: &G::Scalar, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut bytes = Vec::with_capacity(G::SCALAR_SIZE);
+        G::serialize_scalar(scalar, &mut bytes);
+        serialize_bytes(&bytes, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<G::Scalar, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = deserialize_bytes(deserializer)?;
+        if bytes.len() == G::SCALAR_SIZE {
+            G::deserialize_scalar(&bytes)
+                .ok_or_else(|| D::Error::invalid_value(Unexpected::Bytes(&bytes), &"group scalar"))
+        } else {
+            let expected_len = G::SCALAR_SIZE.to_string();
+            Err(D::Error::invalid_length(
+                bytes.len(),
+                &expected_len.as_str(),
+            ))
+        }
+    }
+}
+
+impl<'de, G: Group> Deserialize<'de> for ScalarHelper<G> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::deserialize(deserializer).map(Self)
+    }
+}
+
+/// Helper type to deserialize group elements.
+#[derive(Debug)]
+pub struct ElementHelper<G: Group>(G::Element);
+
+impl<G: Group> ElementHelper<G> {
+    pub fn serialize<S>(element: &G::Element, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+        G::serialize_element(element, &mut bytes);
+        serialize_bytes(&bytes, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<G::Element, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = deserialize_bytes(deserializer)?;
+        if bytes.len() == G::ELEMENT_SIZE {
+            G::deserialize_element(&bytes)
+                .ok_or_else(|| D::Error::invalid_value(Unexpected::Bytes(&bytes), &"group element"))
+        } else {
+            let expected_len = G::ELEMENT_SIZE.to_string();
+            Err(D::Error::invalid_length(
+                bytes.len(),
+                &expected_len.as_str(),
+            ))
+        }
+    }
+}
+
+pub struct ScalarVec<G, const MIN: usize>(PhantomData<G>);
+
+impl<G: Group, const MIN: usize> ScalarVec<G, MIN> {
+    fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    pub fn serialize<S>(scalars: &[G::Scalar], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        debug_assert!(scalars.len() >= MIN);
+
+        let is_human_readable = serializer.is_human_readable();
+        let mut seq = serializer.serialize_seq(Some(scalars.len()))?;
+        for scalar in scalars {
+            let mut bytes = Vec::with_capacity(G::SCALAR_SIZE);
+            G::serialize_scalar(scalar, &mut bytes);
+
+            if is_human_readable {
+                let str = base64::encode_config(&bytes, base64::URL_SAFE_NO_PAD);
+                seq.serialize_element(&str)?;
+            } else {
+                seq.serialize_element(&bytes)?;
+            }
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<G::Scalar>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(Self::new())
+    }
+}
+
+impl<'de, G: Group, const MIN: usize> Visitor<'de> for ScalarVec<G, MIN> {
+    type Value = Vec<G::Scalar>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "at least {} group scalars", MIN)
+    }
+
+    fn visit_seq<S>(self, mut access: S) -> Result<Self::Value, S::Error>
+    where
+        S: SeqAccess<'de>,
+    {
+        let mut scalars = if let Some(size) = access.size_hint() {
+            if size < MIN {
+                return Err(S::Error::invalid_length(size, &self));
+            }
+            Vec::with_capacity(size)
+        } else {
+            Vec::new()
+        };
+
+        while let Some(scalar) = access.next_element::<ScalarHelper<G>>()? {
+            scalars.push(scalar.0);
+        }
+        if scalars.len() >= MIN {
+            Ok(scalars)
+        } else {
+            Err(S::Error::invalid_length(scalars.len(), &self))
+        }
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,6 @@
 //! (De)serialization utils.
 
+use base64ct::{Base64UrlUnpadded, Encoding};
 use serde::{
     de::{Error as DeError, SeqAccess, Unexpected, Visitor},
     ser::SerializeSeq,
@@ -15,7 +16,7 @@ where
     S: Serializer,
 {
     if serializer.is_human_readable() {
-        serializer.serialize_str(&base64::encode_config(value, base64::URL_SAFE_NO_PAD))
+        serializer.serialize_str(&Base64UrlUnpadded::encode_string(value))
     } else {
         serializer.serialize_bytes(value)
     }
@@ -35,7 +36,7 @@ where
         }
 
         fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
-            base64::decode_config(value, base64::URL_SAFE_NO_PAD)
+            Base64UrlUnpadded::decode_vec(value)
                 .map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
         }
 
@@ -185,8 +186,8 @@ impl<G: Group, const MIN: usize> ScalarVec<G, MIN> {
             G::serialize_scalar(scalar, &mut bytes);
 
             if is_human_readable {
-                let str = base64::encode_config(&bytes, base64::URL_SAFE_NO_PAD);
-                seq.serialize_element(&str)?;
+                let string = Base64UrlUnpadded::encode_string(&bytes);
+                seq.serialize_element(&string)?;
             } else {
                 seq.serialize_element(&bytes)?;
             }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -98,7 +98,7 @@ impl<G: Group> Serialize for SecretKey<G> {
     where
         S: Serializer,
     {
-        let mut bytes = Zeroizing::new(Vec::with_capacity(G::SCALAR_SIZE));
+        let mut bytes = Zeroizing::new(vec![0_u8; G::SCALAR_SIZE]);
         G::serialize_scalar(&self.0, &mut bytes);
         serialize_bytes(&bytes, serializer)
     }
@@ -153,7 +153,7 @@ impl<G: Group> ScalarHelper<G> {
     where
         S: Serializer,
     {
-        let mut bytes = Vec::with_capacity(G::SCALAR_SIZE);
+        let mut bytes = vec![0_u8; G::SCALAR_SIZE];
         G::serialize_scalar(scalar, &mut bytes);
         serialize_bytes(&bytes, serializer)
     }
@@ -216,7 +216,7 @@ impl<G: Group> ElementHelper<G> {
     where
         S: Serializer,
     {
-        let mut bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
         G::serialize_element(element, &mut bytes);
         serialize_bytes(&bytes, serializer)
     }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -933,7 +933,7 @@ impl<G: Group> DecryptionShare<G> {
 
     /// Serializes this share into bytes.
     pub fn to_bytes(self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(G::ELEMENT_SIZE);
+        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
         G::serialize_element(&self.dh_element, &mut bytes);
         bytes
     }

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -171,9 +171,9 @@
 
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
-use subtle::ConstantTimeEq;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 
 use std::{
     cmp::Ordering,
@@ -181,13 +181,13 @@ use std::{
     fmt, iter,
 };
 
+#[cfg(feature = "serde")]
+use crate::serde::ElementHelper;
 use crate::{
     group::Group,
     proofs::{LogEqualityProof, ProofOfPossession, TranscriptForGroup},
     Ciphertext, Keypair, PublicKey, SecretKey,
 };
-#[cfg(feature = "serde")]
-use crate::serde::ElementHelper;
 
 /// Computes value of a public polynomial at the specified point in variable time.
 fn polynomial_value<G: Group>(coefficients: &[G::Element], x: G::Scalar) -> G::Element {

--- a/tests/integration/sharing.rs
+++ b/tests/integration/sharing.rs
@@ -40,7 +40,7 @@ impl<G: Group> Rig<G> {
         for i in 0..participants.len() {
             for j in 0..participants.len() {
                 if j != i {
-                    let message = participants[i].message(j);
+                    let message = participants[i].message(j).clone();
                     participants[j].process_message(i, message).unwrap();
                 }
             }


### PR DESCRIPTION
Adds `serde` (de)serialization support for the majority of crate types, implemented as an opt-in feature.