### PR TITLE
Misc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Move `EncryptedChoice` to a separate `app` module. Introduce `EncryptedChoiceParams`
   to encapsulate all parameters related to `EncryptedChoice` creation / verification.
 
+- Generalize `DecryptionShare`s as `VerifiableDecryption`, which can be applied not only
+  with threshold encryption with Shamir's secret sharing, but in other sharing schemes
+  or independently.
+
 ### Fixed
 
 - Remove unused `byteorder` and `smallvec` dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Extend supported operations for `Ciphertext`s, e.g. negation. 
 
+- Expose ciphertext components via getters.
+
 ### Changed
 
 - Update `elliptic-curve` dependency.

--- a/src/decryption.rs
+++ b/src/decryption.rs
@@ -1,0 +1,220 @@
+//! Verifiable decryption.
+
+use merlin::Transcript;
+use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "serde")]
+use crate::serde::ElementHelper;
+use crate::{
+    alloc::{vec, Vec},
+    group::Group,
+    proofs::{LogEqualityProof, TranscriptForGroup},
+    Ciphertext, DiscreteLogTable, Keypair, PublicKey, VerificationError,
+};
+
+/// Verifiable decryption for a certain [`Ciphertext`] in the ElGamal encryption scheme.
+/// Usable both for standalone proofs and in threshold encryption.
+///
+/// # Construction
+///
+/// Decryption is represented by a single group element – the result of combining
+/// a [`SecretKey`](crate::SecretKey) scalar `x` with the random element of the ciphertext `R`
+/// (i.e., `D = [x]R`, the Diffie – Hellman construction).
+/// This element can retrieved using [`Self::as_element()`] and applied to a ciphertext using
+/// [`Self::decrypt()`] or [`Self::decrypt_to_element()`].
+///
+/// The decryption can be proven with the help of a standard [`LogEqualityProof`]. Indeed,
+/// to prove the validity of decryption, it is sufficient to prove `dlog_R(D) = dlog_G(K)`,
+/// where `G` is the conventional group generator and `K = [x]G` is the public key for encryption.
+///
+/// # Examples
+///
+/// `VerifiableDecryption` can be used either within the threshold encryption scheme provided by
+/// the [`sharing`](crate::sharing) module, or independently (for example, if another approach
+/// to secret sharing is used, or if the encryption key is not shared at all).
+/// An example of standalone usage is outlined below:
+///
+/// ```
+/// # use elastic_elgamal::{
+/// #     group::Ristretto, CandidateDecryption, VerifiableDecryption, Keypair, DiscreteLogTable,
+/// # };
+/// # use merlin::Transcript;
+/// # use rand::thread_rng;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut rng = thread_rng();
+/// let keys = Keypair::<Ristretto>::generate(&mut rng);
+/// // Suppose the `keys` holder wants to prove decryption
+/// // of the following ciphertext:
+/// let ciphertext = keys.public().encrypt(42_u64, &mut rng);
+/// let (decryption, proof) = VerifiableDecryption::new(
+///     ciphertext,
+///     &keys,
+///     &mut Transcript::new(b"decryption"),
+///     &mut rng,
+/// );
+///
+/// // This proof can then be universally verified:
+/// let candidate_decryption = CandidateDecryption::from(decryption);
+/// let decryption = candidate_decryption.verify(
+///     ciphertext,
+///     keys.public(),
+///     &proof,
+///     &mut Transcript::new(b"decryption"),
+/// )?;
+/// assert_eq!(
+///     decryption.decrypt(ciphertext, &DiscreteLogTable::new(0..50)),
+///     Some(42)
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+pub struct VerifiableDecryption<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ElementHelper::<G>"))]
+    dh_element: G::Element,
+}
+
+impl<G: Group> VerifiableDecryption<G> {
+    pub(crate) fn from_element(dh_element: G::Element) -> Self {
+        Self { dh_element }
+    }
+
+    /// Creates a decryption for the specified `ciphertext` under `keys` together with
+    /// a zero-knowledge proof of validity.
+    ///
+    /// See [`CandidateDecryption::verify()`] for the verification counterpart.
+    pub fn new<R: CryptoRng + RngCore>(
+        ciphertext: Ciphertext<G>,
+        keys: &Keypair<G>,
+        transcript: &mut Transcript,
+        rng: &mut R,
+    ) -> (Self, LogEqualityProof<G>) {
+        // All inputs except from `ciphertext.blinded_element` are committed in the `proof`,
+        // and it is not necessary to commit in order to allow iteratively recomputing
+        // the ciphertext.
+        transcript.start_proof(b"decryption_with_custom_key");
+
+        let dh_element = ciphertext.random_element * keys.secret().expose_scalar();
+        let proof = LogEqualityProof::new(
+            &PublicKey::from_element(ciphertext.random_element),
+            keys.secret(),
+            (keys.public().as_element(), dh_element),
+            transcript,
+            rng,
+        );
+
+        (Self { dh_element }, proof)
+    }
+
+    /// Returns the group element encapsulated in this decryption.
+    pub fn as_element(&self) -> &G::Element {
+        &self.dh_element
+    }
+
+    /// Serializes this decryption into bytes.
+    pub fn to_bytes(self) -> Vec<u8> {
+        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
+        G::serialize_element(&self.dh_element, &mut bytes);
+        bytes
+    }
+
+    /// Decrypts the provided ciphertext and returns the produced group element.
+    ///
+    /// As the ciphertext does not include a MAC or another way to assert integrity,
+    /// this operation cannot fail. If the ciphertext is not produced properly (e.g., it targets
+    /// another receiver), the returned group element will be garbage.
+    pub fn decrypt_to_element(&self, encrypted: Ciphertext<G>) -> G::Element {
+        encrypted.blinded_element - self.dh_element
+    }
+
+    /// Decrypts the provided ciphertext and returns the original encrypted value.
+    ///
+    /// `lookup_table` is used to find encrypted values based on the original decrypted
+    /// group element. That is, it must contain all valid plaintext values. If the value
+    /// is not in the table, this method will return `None`.
+    pub fn decrypt(
+        &self,
+        encrypted: Ciphertext<G>,
+        lookup_table: &DiscreteLogTable<G>,
+    ) -> Option<u64> {
+        lookup_table.get(&self.decrypt_to_element(encrypted))
+    }
+}
+
+/// Candidate for a [`VerifiableDecryption`] that is not yet verified. This presentation should be
+/// used for decryption data retrieved from an untrusted source.
+///
+/// Decryption data can be verified using [`Self::verify()`]. The threshold encryption scheme
+/// implemented in the [`sharing`](crate::sharing) module has its own verification procedure
+/// in [`PublicKeySet`].
+///
+/// [`PublicKeySet`]: crate::sharing::PublicKeySet
+///
+/// # Examples
+///
+/// See [`VerifiableDecryption`] for an example of usage.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent, bound = ""))]
+pub struct CandidateDecryption<G: Group> {
+    inner: VerifiableDecryption<G>,
+}
+
+impl<G: Group> CandidateDecryption<G> {
+    /// Deserializes decryption data from `bytes`. Returns `None` if the data is malformed.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() == G::ELEMENT_SIZE {
+            let dh_element = G::deserialize_element(bytes)?;
+            Some(Self {
+                inner: VerifiableDecryption { dh_element },
+            })
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn dh_element(self) -> G::Element {
+        self.inner.dh_element
+    }
+
+    /// Verifies this as decryption for `ciphertext` under `key` using the provided
+    /// zero-knowledge `proof`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `proof` does not verify.
+    pub fn verify(
+        self,
+        ciphertext: Ciphertext<G>,
+        key: &PublicKey<G>,
+        proof: &LogEqualityProof<G>,
+        transcript: &mut Transcript,
+    ) -> Result<VerifiableDecryption<G>, VerificationError> {
+        transcript.start_proof(b"decryption_with_custom_key");
+
+        let dh_element = self.dh_element();
+        proof.verify(
+            &PublicKey::from_element(ciphertext.random_element),
+            (key.as_element(), dh_element),
+            transcript,
+        )?;
+        Ok(self.inner)
+    }
+
+    /// Converts this candidate decryption into a [`VerifiableDecryption`]
+    /// **without** verifying it.
+    /// This only semantically correct if the data was verified in some other way.
+    pub fn into_unchecked(self) -> VerifiableDecryption<G> {
+        self.inner
+    }
+}
+
+impl<G: Group> From<VerifiableDecryption<G>> for CandidateDecryption<G> {
+    fn from(decryption: VerifiableDecryption<G>) -> Self {
+        Self { inner: decryption }
+    }
+}

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -18,6 +18,20 @@ use crate::{
 
 /// Ciphertext for ElGamal encryption.
 ///
+/// A ciphertext consists of 2 group elements: the random element `R` and a blinded encrypted
+/// value `B`. If the ciphertext encrypts integer value `v`, it holds that
+///
+/// ```text
+/// R = [r]G;
+/// B = [v]G + [r]K = [v]G + [k]R;
+/// ```
+///
+/// where:
+///
+/// - `G` is the conventional group generator
+/// - `r` is a random scalar selected by the encrypting party
+/// - `K` and `k` are the recipient's public and private keys, respectively.
+///
 /// Ciphertexts are partially homomorphic: they can be added together or multiplied by a scalar
 /// value.
 ///
@@ -118,6 +132,16 @@ impl<G: Group> Ciphertext<G> {
             random_element: G::identity(),
             blinded_element: G::mul_generator(&scalar),
         }
+    }
+
+    /// Returns a reference to the random element.
+    pub fn random_element(&self) -> &G::Element {
+        &self.random_element
+    }
+
+    /// Returns a reference to the blinded element.
+    pub fn blinded_element(&self) -> &G::Element {
+        &self.blinded_element
     }
 
     /// Serializes this ciphertext as two group elements (the random element,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 )]
 
 pub mod app;
+mod decryption;
 mod encryption;
 pub mod group;
 mod keys;
@@ -119,6 +120,7 @@ mod sealed {
 }
 
 pub use crate::{
+    decryption::{CandidateDecryption, VerifiableDecryption},
     encryption::{Ciphertext, CiphertextWithValue, DiscreteLogTable},
     keys::{Keypair, PublicKey, PublicKeyConversionError, SecretKey},
     proofs::{

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -507,7 +507,7 @@ impl<G: Group> PublicKeySet<G> {
             (key_share, dh_element),
             &mut transcript,
         )?;
-        Ok(DecryptionShare::new(dh_element))
+        Ok(DecryptionShare::from_element(dh_element))
     }
 }
 

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -63,7 +63,9 @@
 //! Threshold encryption scheme requiring 2 of 3 participants.
 //!
 //! ```
-//! # use elastic_elgamal::{group::Ristretto, sharing::*, Ciphertext, DiscreteLogTable};
+//! # use elastic_elgamal::{
+//! #     group::Ristretto, sharing::*, CandidateDecryption, Ciphertext, DiscreteLogTable,
+//! # };
 //! # use rand::thread_rng;
 //! # use std::error::Error as StdError;
 //! # fn main() -> Result<(), Box<dyn StdError>> {
@@ -96,16 +98,16 @@
 //! let dec_shares = shares_with_proofs
 //!     .enumerate()
 //!     .map(|(i, (share, proof))| {
-//!         let share = CandidateShare::from_bytes(&share.to_bytes()).unwrap();
+//!         let share = CandidateDecryption::from_bytes(&share.to_bytes()).unwrap();
 //!         key_set.verify_share(share, enc, i, &proof).unwrap()
 //!     });
 //!
-//! // Reconstruct decryption from the shares.
-//! let dec = DecryptionShare::combine(params, enc, dec_shares.enumerate())
-//!     .unwrap();
-//! // Use lookup table to map decryption back to scalar.
+//! // Combine decryption shares.
+//! let combined = params.combine_shares(dec_shares.enumerate()).unwrap();
+//! // Use a lookup table to decrypt back to scalar.
 //! let lookup_table = DiscreteLogTable::<Ristretto>::new(0..10);
-//! assert_eq!(lookup_table.get(&dec), Some(encrypted_value));
+//! let dec = combined.decrypt(enc, &lookup_table);
+//! assert_eq!(dec, Some(encrypted_value));
 //! # Ok(())
 //! # }
 //! ```
@@ -123,11 +125,11 @@ use crate::{
     alloc::Vec,
     group::Group,
     proofs::{LogEqualityProof, ProofOfPossession, TranscriptForGroup, VerificationError},
-    Ciphertext, PublicKey,
+    CandidateDecryption, Ciphertext, PublicKey, VerifiableDecryption,
 };
 
 mod participant;
-pub use self::participant::{ActiveParticipant, CandidateShare, Dealer, DecryptionShare};
+pub use self::participant::{ActiveParticipant, Dealer};
 
 /// Computes multipliers for the Lagrange polynomial interpolation based on the function value
 /// at the given points. The indexes are zero-based, hence points are determined as
@@ -248,6 +250,39 @@ impl Params {
         assert!(shares > 0);
         assert!(threshold > 0 && threshold <= shares);
         Self { shares, threshold }
+    }
+
+    /// Combines shares decrypting the specified `ciphertext`. The shares must be provided
+    /// together with the 0-based indexes of the participants they are coming from.
+    ///
+    /// Returns the combined decryption, or `None` if the number of shares is insufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index in `shares` exceeds the maximum participant's index as per `params`.
+    pub fn combine_shares<G: Group>(
+        self,
+        shares: impl IntoIterator<Item = (usize, VerifiableDecryption<G>)>,
+    ) -> Option<VerifiableDecryption<G>> {
+        let (indexes, shares): (Vec<_>, Vec<_>) = shares
+            .into_iter()
+            .take(self.threshold)
+            .map(|(index, share)| (index, *share.as_element()))
+            .unzip();
+        if shares.len() < self.threshold {
+            return None;
+        }
+        assert!(
+            indexes.iter().all(|&index| index < self.shares),
+            "Invalid share indexes {:?}; expected values in 0..{}",
+            indexes.iter().copied(),
+            self.shares
+        );
+
+        let (denominators, scale) = lagrange_coefficients::<G>(&indexes);
+        let restored_value = G::vartime_multi_mul(&denominators, shares);
+        let dh_element = restored_value * &scale;
+        Some(VerifiableDecryption::from_element(dh_element))
     }
 }
 
@@ -491,11 +526,11 @@ impl<G: Group> PublicKeySet<G> {
     /// Returns an error if the `proof` does not verify.
     pub fn verify_share(
         &self,
-        candidate_share: CandidateShare<G>,
+        candidate_share: CandidateDecryption<G>,
         ciphertext: Ciphertext<G>,
         index: usize,
         proof: &LogEqualityProof<G>,
-    ) -> Result<DecryptionShare<G>, VerificationError> {
+    ) -> Result<VerifiableDecryption<G>, VerificationError> {
         let key_share = self.participant_keys[index].as_element();
         let dh_element = candidate_share.dh_element();
         let mut transcript = Transcript::new(b"elgamal_decryption_share");
@@ -507,7 +542,7 @@ impl<G: Group> PublicKeySet<G> {
             (key_share, dh_element),
             &mut transcript,
         )?;
-        Ok(DecryptionShare::from_element(dh_element))
+        Ok(VerifiableDecryption::from_element(dh_element))
     }
 }
 

--- a/src/sharing/participant.rs
+++ b/src/sharing/participant.rs
@@ -11,14 +11,12 @@ use subtle::ConstantTimeEq;
 
 use core::iter;
 
-#[cfg(feature = "serde")]
-use crate::serde::ElementHelper;
 use crate::{
-    alloc::{vec, Vec},
+    alloc::Vec,
     group::Group,
-    proofs::{LogEqualityProof, ProofOfPossession, TranscriptForGroup},
-    sharing::{lagrange_coefficients, Error, Params, PublicKeySet},
-    Ciphertext, Keypair, PublicKey, SecretKey, VerificationError,
+    proofs::{LogEqualityProof, ProofOfPossession},
+    sharing::{Error, Params, PublicKeySet},
+    Ciphertext, Keypair, PublicKey, SecretKey, VerifiableDecryption,
 };
 
 /// Dealer in a [Feldman verifiable secret sharing][feldman-vss] scheme.
@@ -88,7 +86,7 @@ impl<G: Group> Dealer<G> {
 
 /// Personalized state of a participant of a threshold ElGamal encryption scheme
 /// once the participant receives the secret share from the [`Dealer`].
-/// At this point, the participant can produce [`DecryptionShare`]s.
+/// At this point, the participant can produce [`VerifiableDecryption`]s.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound = ""))]
@@ -159,13 +157,13 @@ impl<G: Group> ActiveParticipant<G> {
         )
     }
 
-    /// Creates a [`DecryptionShare`] for the specified `ciphertext` together with a proof
+    /// Creates a [`VerifiableDecryption`] for the specified `ciphertext` together with a proof
     /// of its validity. `rng` is used to generate the proof.
     pub fn decrypt_share<R>(
         &self,
         ciphertext: Ciphertext<G>,
         rng: &mut R,
-    ) -> (DecryptionShare<G>, LogEqualityProof<G>)
+    ) -> (VerifiableDecryption<G>, LogEqualityProof<G>)
     where
         R: CryptoRng + RngCore,
     {
@@ -182,208 +180,7 @@ impl<G: Group> ActiveParticipant<G> {
             &mut transcript,
             rng,
         );
-        (DecryptionShare { dh_element }, proof)
-    }
-}
-
-/// Decryption share for a certain [`Ciphertext`] in a threshold ElGamal encryption scheme.
-///
-/// # Construction
-///
-/// The share is a single group element – the result of combining
-/// participant's secret scalar with the random element of the ciphertext (i.e.,
-/// the Diffie – Hellman construction). This element can retrieved using [`Self::as_element()`].
-///
-/// # Examples
-///
-/// [`DecryptionShare`] can be used either within the threshold encryption scheme provided by
-/// [`ActiveParticipant::decrypt_share()`], or independently (for example, if another approach
-/// to secret sharing is used). An example of standalone usage is outlined below:
-///
-/// ```
-/// # use elastic_elgamal::{group::Ristretto, sharing::{CandidateShare, DecryptionShare}, Keypair};
-/// # use merlin::Transcript;
-/// # use rand::thread_rng;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut rng = thread_rng();
-/// let keys = Keypair::<Ristretto>::generate(&mut rng);
-/// // Suppose the `keys` holder wants to prove decryption
-/// // of the following ciphertext:
-/// let ciphertext = keys.public().encrypt(42_u64, &mut rng);
-/// let (share, proof) = DecryptionShare::new(
-///     ciphertext,
-///     &keys,
-///     &mut Transcript::new(b"decryption_share"),
-///     &mut rng,
-/// );
-///
-/// // This proof can then be universally verified:
-/// let candidate_share = CandidateShare::from(share);
-/// let restored_share = candidate_share.verify(
-///     ciphertext,
-///     keys.public(),
-///     &proof,
-///     &mut Transcript::new(b"decryption_share"),
-/// )?;
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound = ""))]
-pub struct DecryptionShare<G: Group> {
-    #[cfg_attr(feature = "serde", serde(with = "ElementHelper::<G>"))]
-    dh_element: G::Element,
-}
-
-impl<G: Group> DecryptionShare<G> {
-    pub(super) fn from_element(dh_element: G::Element) -> Self {
-        Self { dh_element }
-    }
-
-    /// Creates a decryption for the specified `ciphertext` under `keys` together with
-    /// a zero-knowledge proof of validity.
-    ///
-    /// This is a lower-level counterpart to [`ActiveParticipant::decrypt_share()`].
-    /// See [`CandidateShare::verify()`] for a verification counterpart.
-    pub fn new<R: CryptoRng + RngCore>(
-        ciphertext: Ciphertext<G>,
-        keys: &Keypair<G>,
-        transcript: &mut Transcript,
-        rng: &mut R,
-    ) -> (Self, LogEqualityProof<G>) {
-        // All inputs except from `ciphertext.blinded_element` are committed in the `proof`,
-        // and it is not necessary to commit in order to allow iteratively recomputing
-        // the ciphertext.
-        transcript.start_proof(b"decryption_share_with_custom_key");
-
-        let dh_element = ciphertext.random_element * keys.secret().expose_scalar();
-        let proof = LogEqualityProof::new(
-            &PublicKey::from_element(ciphertext.random_element),
-            keys.secret(),
-            (keys.public().as_element(), dh_element),
-            transcript,
-            rng,
-        );
-
-        (Self { dh_element }, proof)
-    }
-
-    /// Combines shares decrypting the specified `ciphertext`. The shares must be provided
-    /// together with the 0-based indexes of the participants they are coming from.
-    ///
-    /// Returns the decrypted value, or `None` if the number of shares is insufficient.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any index in `shares` exceeds the maximum participant's index as per `params`.
-    pub fn combine(
-        params: Params,
-        ciphertext: Ciphertext<G>,
-        shares: impl IntoIterator<Item = (usize, Self)>,
-    ) -> Option<G::Element> {
-        let (indexes, shares): (Vec<_>, Vec<_>) = shares
-            .into_iter()
-            .take(params.threshold)
-            .map(|(index, share)| (index, share.dh_element))
-            .unzip();
-        if shares.len() < params.threshold {
-            return None;
-        }
-        assert!(
-            indexes.iter().all(|&index| index < params.shares),
-            "Invalid share indexes {:?}; expected values in 0..{}",
-            indexes.iter().copied(),
-            params.shares
-        );
-
-        let (denominators, scale) = lagrange_coefficients::<G>(&indexes);
-        let restored_value = G::vartime_multi_mul(&denominators, shares);
-        let dh_element = restored_value * &scale;
-        Some(ciphertext.blinded_element - dh_element)
-    }
-
-    /// Returns the group element encapsulated in this share.
-    pub fn as_element(&self) -> &G::Element {
-        &self.dh_element
-    }
-
-    /// Serializes this share into bytes.
-    pub fn to_bytes(self) -> Vec<u8> {
-        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
-        G::serialize_element(&self.dh_element, &mut bytes);
-        bytes
-    }
-}
-
-/// Candidate for a [`DecryptionShare`] that is not yet verified. This presentation should be
-/// used for shares retrieved from an untrusted source.
-///
-/// A share can be verified using [`PublicKeySet::verify_share()`] or [`Self::verify()`].
-/// The second option is low-level and could be used with secret sharing schemes
-/// differing from Shamir's secret sharing implemented by [`PublicKeySet`].
-///
-/// # Examples
-///
-/// See [`DecryptionShare`] for an example of usage.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent, bound = ""))]
-pub struct CandidateShare<G: Group> {
-    inner: DecryptionShare<G>,
-}
-
-impl<G: Group> CandidateShare<G> {
-    /// Deserializes a share from `bytes`. Returns `None` if the share is malformed.
-    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() == G::ELEMENT_SIZE {
-            let dh_element = G::deserialize_element(bytes)?;
-            Some(Self {
-                inner: DecryptionShare { dh_element },
-            })
-        } else {
-            None
-        }
-    }
-
-    pub(super) fn dh_element(self) -> G::Element {
-        self.inner.dh_element
-    }
-
-    /// Verifies this as a decryption share for `ciphertext` under `key` using the provided
-    /// zero-knowledge `proof`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `proof` does not verify.
-    pub fn verify(
-        self,
-        ciphertext: Ciphertext<G>,
-        key: &PublicKey<G>,
-        proof: &LogEqualityProof<G>,
-        transcript: &mut Transcript,
-    ) -> Result<DecryptionShare<G>, VerificationError> {
-        transcript.start_proof(b"decryption_share_with_custom_key");
-
-        let dh_element = self.dh_element();
-        proof.verify(
-            &PublicKey::from_element(ciphertext.random_element),
-            (key.as_element(), dh_element),
-            transcript,
-        )?;
-        Ok(self.inner)
-    }
-
-    /// Converts this candidate share into a [`DecryptionShare`] **without** verifying its validity.
-    /// This only semantically correct if the share was verified in some other way.
-    pub fn into_unchecked(self) -> DecryptionShare<G> {
-        self.inner
-    }
-}
-
-impl<G: Group> From<DecryptionShare<G>> for CandidateShare<G> {
-    fn from(share: DecryptionShare<G>) -> Self {
-        Self { inner: share }
+        (VerifiableDecryption::from_element(dh_element), proof)
     }
 }
 
@@ -439,7 +236,7 @@ mod tests {
         // a0 +   a1 = alice_share.dh_element;
         // a0 + 2*a1 = bob_share.dh_element;
         let composite_dh_element =
-            alice_share.dh_element * Scalar25519::from(2_u64) - bob_share.dh_element;
+            *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
         let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));
         assert_eq!(composite_dh_element, ciphertext.blinded_element - message);
     }


### PR DESCRIPTION
- Exposes ElGamal ciphertext components via getters.
- Generalizes `DecryptionShare`s as `VerifiableDecryption`, which can be applied not only with threshold encryption with Shamir's secret sharing, but in other sharing schemes or independently.