### PR TITLE
Fix `serde` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,12 +72,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: "Clippy: all features"
           args: --workspace --all-features --all-targets -- -D warnings
-      - name: Clippy (no features)
+      - name: Clippy (features=hashbrown)
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: "Clippy: no features"
+          name: "Clippy: features=hashbrown"
           args: --lib --no-default-features --features hashbrown -- -D warnings
+      - name: Clippy (features=hashbrown,serde)
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Clippy: features=hashbrown,serde"
+          args: --lib --no-default-features --features hashbrown,serde -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `serde` feature. The `serde` dependency requires the `alloc` feature enabled,
+  but this was not declared previously.
+
 ## 0.2.0 - 2022-06-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand_core = { version = "0.6.2", default-features = false }
 zeroize = { version = "1.3.0", default-features = false }
 
 # Enables `Serialize` / `Deserialize` implementation for most types in the crate.
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 
 # Private dependencies (not exposed via public APIs).
 base64ct = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn public_key_deserialization_of_non_element() {
         let err = serde_json::from_str::<PublicKey<Ristretto>>(
-            "\"tNDkeYUVQWgh34d-RqaElOk7yFB8d2qCh5f4Vi2euT1\"",
+            "\"tNDkeYUVQWgh34d-RqaElOk7yFB8d2qCh5f4Vi2euT0\"",
         )
         .unwrap_err();
         let err_string = err.to_string();
@@ -392,10 +392,10 @@ mod tests {
 
     #[test]
     fn secret_key_deserialization_of_invalid_scalar() {
-        // Last `__` chars set the upper byte of the scalar bytes to 0xff, which is invalid
+        // Last `_8` chars set the upper byte of the scalar bytes to 0xff, which is invalid
         // (all scalars are less than 2^253).
         let err = serde_json::from_str::<SecretKey<Ristretto>>(
-            "\"nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM__\"",
+            "\"nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM_8\"",
         )
         .unwrap_err();
         let err_string = err.to_string();
@@ -453,7 +453,7 @@ mod tests {
 
         json.as_object_mut().unwrap().insert(
             "scalar".into(),
-            "nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM__".into(),
+            "nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM_8".into(),
         );
         let err = serde_json::from_value::<TestObject<Ristretto>>(json).unwrap_err();
         let err_string = err.to_string();
@@ -482,7 +482,7 @@ mod tests {
 
         json.as_object_mut().unwrap().insert(
             "element".into(),
-            "nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM__".into(),
+            "nN3xf7lSOX0_zs6QPBwWHYi0Dkx2Ln_z1MPwnbzaM_8".into(),
         );
         let err = serde_json::from_value::<TestObject<Ristretto>>(json).unwrap_err();
         let err_string = err.to_string();


### PR DESCRIPTION
The `serde` dependency requires the `alloc` feature enabled, but this was not declared previously.