### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.2.1 - 2022-07-04
+
 ### Fixed
 
 - Fix `serde` feature. The `serde` dependency requires the `alloc` feature enabled,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-elgamal"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
 edition = "2021"
 rust-version = "1.57"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-elastic-elgamal = "0.2.0" 
+elastic-elgamal = "0.2.1"
 ```
 
 ### Single-choice polling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/elastic-elgamal/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/elastic-elgamal/0.2.1")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
This release fixes a bug with the `serde` feature that prevented from building docs on `docs.rs` and from GitHub Actions.