### PR TITLE
Commitment equivalence proof

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --all-targets
+          args: --workspace --features serde --all-targets
       - name: Run doc tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --doc
+          args: --workspace --features serde --doc
 
   build:
     runs-on: ubuntu-latest
@@ -66,12 +66,12 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-      - name: Clippy
+      - name: Clippy (non-conflicting features)
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: "Clippy: all features"
-          args: --workspace --all-features --all-targets -- -D warnings
+          name: "Clippy: non-conflicting features"
+          args: --workspace --features serde --all-targets -- -D warnings
       - name: Clippy (features=hashbrown)
         uses: actions-rs/clippy-check@v1
         with:
@@ -84,33 +84,44 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: "Clippy: features=hashbrown,serde,dalek/u32"
           args: --lib --no-default-features --features hashbrown,serde,curve25519-dalek/u32_backend -- -D warnings
+      - name: Clippy (features=std,serde,dalek-ng)
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Clippy: features=std,serde,dalek-ng"
+          args: --lib --no-default-features --features std,serde,curve25519-dalek-ng/u64_backend -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --all-targets
+          args: --workspace --features serde --all-targets
       - name: Run doc tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --doc
+          args: --workspace --features serde --doc
 
       - name: Run voting (ristretto)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p elastic-elgamal --all-features --example voting -- --options 5 --votes 50 --talliers 3/4
+          args: -p elastic-elgamal --features serde --example voting -- --options 5 --votes 50 --talliers 3/4
       - name: Run voting (quadratic, k256)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p elastic-elgamal --all-features --example voting -- --qv k256
+          args: -p elastic-elgamal --features serde --example voting -- --qv k256
       - name: Run range
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: -p elastic-elgamal --all-features --example range
+          args: -p elastic-elgamal --features serde --example range
+      - name: Run equivalence
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -p elastic-elgamal --no-default-features --features std,serde,curve25519-dalek-ng/u64_backend --example equivalence
 
   build-nostd:
     runs-on: ubuntu-latest
@@ -136,7 +147,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --lib --no-default-features --features hashbrown --target thumbv7m-none-eabi -Z avoid-dev-deps
+          args: --lib --no-default-features --features hashbrown,curve25519-dalek/u32_backend --target thumbv7m-none-eabi -Z avoid-dev-deps
 
   document:
     if: github.event_name == 'push'
@@ -164,7 +175,7 @@ jobs:
 
       - name: Build docs
         run: |
-          cargo clean --doc && cargo rustdoc -p elastic-elgamal --all-features -- --cfg docsrs
+          cargo clean --doc && cargo rustdoc -p elastic-elgamal --features serde -- --cfg docsrs
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Make `curve25519-dalek` dependency optional and do not force the choice of its math backend.
   The dependency is still enabled by default.
+- Allow for the `curve25519-dalek-ng` crypto backend as an alternative to `curve25519-dalek`.
+  This may be beneficial for applications that use [`bulletproofs`] or other libraries 
+  depending on `curve25519-dalek-ng`.
+- Implement zero-knowledge proof of equivalence between an ElGamal ciphertext and
+  a Pedersen commitment in the same group. This proof can be used to switch 
+  from frameworks applicable to ElGamal ciphertexts, to ones applicable to Pedersen commitments 
+  (e.g., Bulletproofs for range proofs).
 
 ## 0.2.1 - 2022-07-04
 
@@ -63,3 +70,5 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ## 0.1.0 - 2021-06-28
 
 The initial release of `elastic-elgamal`.
+
+[`bulletproofs`]: https://crates.io/crates/bulletproofs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ with pluggable crypto backend
 """
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["serde"]
 # Set `docsrs` to enable unstable `doc(cfg(...))` attributes.
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Public dependencies (present in public API of the crate).
-curve25519-dalek = { version = "3.1.0", default-features = false, features = ["alloc"], optional = true }
 elliptic-curve = { version = "0.12.0", features = ["sec1"] }
 rand_core = { version = "0.6.2", default-features = false }
 zeroize = { version = "1.3.0", default-features = false, features = ["alloc"] }
@@ -35,6 +34,22 @@ hashbrown = { version = "0.12.0", optional = true }
 merlin = { version = "3.0.0", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 subtle = { version = "2.4.0", default-features = false }
+
+# Crypto backend to support Curve25519 prime subgroup and Ristretto255 group;
+# a public dependency.
+[dependencies.curve25519-dalek]
+version = "3.1.0"
+default-features = false
+features = ["alloc"]
+optional = true
+
+# Crypto backend to support Curve25519 prime subgroup and Ristretto255 group;
+# a public dependency. Alternative and mutually exclusive with `curve25519-dalek`.
+[dependencies.curve25519-dalek-ng]
+version = "4.1.1"
+default-features = false
+features = ["alloc"]
+optional = true
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ name = "range"
 path = "examples/range.rs"
 required-features = ["default", "serde"]
 
+[[example]]
+name = "equivalence"
+path = "examples/equivalence.rs"
+required-features = ["curve25519-dalek-ng/u64_backend", "serde"]
+
 [[test]]
 name = "integration"
 path = "tests/integration/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ features = ["alloc"]
 optional = true
 
 [dev-dependencies]
+bulletproofs = "4.0.0"
 criterion = "0.3.4"
 doc-comment = "0.3.3"
 insta = "1.8.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![no_std supported](https://img.shields.io/badge/no__std-tested-green.svg)
 
 **Documentation:** [![Docs.rs](https://docs.rs/elastic-elgamal/badge.svg)](https://docs.rs/elastic-elgamal/)
-[![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/elastic-elgamal/elastic_elgamal/)
+[![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/elastic-elgamal/elastic_elgamal/)
 
 Implementation of [ElGamal encryption] and related zero-knowledge proofs
 with pluggable crypto backend.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The following protocols and high-level applications are included:
 - Additively homomorphic ElGamal encryption
 - Zero-knowledge proofs of zero encryption and Boolean value encryption
 - Zero-knowledge range proofs for ElGamal ciphertexts
+- Zero-knowledge proof of equivalence between an ElGamal ciphertext and
+  a Pedersen commitment in the same group
 - Additively homomorphic m-of-n choice encryption with a zero-knowledge
   proof of correctness
 - Additively homomorphic [quadratic voting] with a zero-knowledge

--- a/examples/equivalence.rs
+++ b/examples/equivalence.rs
@@ -1,0 +1,90 @@
+//! Example showing how to use ElGamal ciphertext - Pedersen commitment equivalence proof
+//! together with proofs on commitments (in this case, a range proof using [Bulletproofs]).
+//!
+//! Note that the example requires the non-default `curve25519-dalek-ng` crypto backend to run.
+//!
+//! [Bulletproofs]: https://crypto.stanford.edu/bulletproofs/
+
+use base64ct::{Base64UrlUnpadded, Encoding};
+use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+use merlin::Transcript;
+use rand::thread_rng;
+
+use std::env;
+
+use elastic_elgamal::{
+    group::Ristretto, Ciphertext, CiphertextWithValue, CommitmentEquivalenceProof, Keypair,
+    SecretKey,
+};
+
+const BULLETPROOFS_CAPACITY: usize = 64;
+
+fn main() {
+    let mut rng = thread_rng();
+    let (receiver, _) = Keypair::<Ristretto>::generate(&mut rng).into_tuple();
+    let value = env::args().nth(1).map_or(424_242, |arg| {
+        arg.parse().expect("cannot parse value as `u64` integer")
+    });
+    let ciphertext = CiphertextWithValue::new(value, &receiver, &mut rng).generalize();
+    println!("Encrypted value: {}", value);
+
+    let commitment_gens = PedersenGens::default();
+    let bulletproof_gens = BulletproofGens::new(BULLETPROOFS_CAPACITY, 1);
+    let blinding = SecretKey::generate(&mut rng);
+    let mut transcript = Transcript::new(b"equiv_and_bulletproof");
+    let (equiv_proof, commitment) = CommitmentEquivalenceProof::new(
+        &ciphertext,
+        &receiver,
+        &blinding,
+        commitment_gens.B_blinding,
+        &mut transcript,
+        &mut rng,
+    );
+    let (range_proof, same_commitment) = RangeProof::prove_single_with_rng(
+        &bulletproof_gens,
+        &commitment_gens,
+        &mut transcript,
+        value,
+        blinding.expose_scalar(),
+        BULLETPROOFS_CAPACITY,
+        &mut rng,
+    )
+    .expect("failed creating proof");
+
+    // Commitments returned in both cases are equivalent.
+    assert_eq!(commitment.compress(), same_commitment);
+    let ciphertext = Ciphertext::from(ciphertext);
+
+    let combined = serde_json::json!({
+        "ciphertext": &ciphertext,
+        "commitment": Base64UrlUnpadded::encode_string(same_commitment.as_bytes()),
+        "equiv": equiv_proof,
+        "range": Base64UrlUnpadded::encode_string(&range_proof.to_bytes()),
+    });
+    println!(
+        "Created proof: {}",
+        serde_json::to_string_pretty(&combined).unwrap()
+    );
+
+    // Check that proofs verify.
+    let mut transcript = Transcript::new(b"equiv_and_bulletproof");
+    equiv_proof
+        .verify(
+            &ciphertext,
+            &receiver,
+            commitment,
+            commitment_gens.B_blinding,
+            &mut transcript,
+        )
+        .unwrap();
+    range_proof
+        .verify_single(
+            &bulletproof_gens,
+            &commitment_gens,
+            &mut transcript,
+            &same_commitment,
+            BULLETPROOFS_CAPACITY,
+        )
+        .unwrap();
+    println!("Proofs successfully verified!");
+}

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -434,11 +434,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{group::Ristretto, Keypair};
-
-    use curve25519_dalek::scalar::Scalar as Curve25519Scalar;
     use rand::{thread_rng, Rng};
+
+    use super::*;
+    use crate::{curve25519::scalar::Scalar as Curve25519Scalar, group::Ristretto, Keypair};
 
     #[test]
     fn ciphertext_addition() {

--- a/src/group/curve25519.rs
+++ b/src/group/curve25519.rs
@@ -21,7 +21,7 @@ use crate::group::{ElementOps, Group, RandomBytesProvider, ScalarOps};
 /// (If it *is* a concern, beware of [cofactor pitfalls]!)
 ///
 /// [`Ristretto`]: crate::group::Ristretto
-/// [pitfalls]: https://ristretto.group/why_ristretto.html#pitfalls-of-a-cofactor
+/// [cofactor pitfalls]: https://ristretto.group/why_ristretto.html#pitfalls-of-a-cofactor
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     docsrs,

--- a/src/group/curve25519.rs
+++ b/src/group/curve25519.rs
@@ -1,13 +1,13 @@
-use curve25519_dalek::{
+use rand_core::{CryptoRng, RngCore};
+
+use core::convert::TryInto;
+
+use crate::curve25519::{
     constants::{ED25519_BASEPOINT_POINT, ED25519_BASEPOINT_TABLE},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{Identity, IsIdentity, MultiscalarMul, VartimeMultiscalarMul},
 };
-use rand_core::{CryptoRng, RngCore};
-
-use core::convert::TryInto;
-
 use crate::group::{ElementOps, Group, RandomBytesProvider, ScalarOps};
 
 /// Prime-order subgroup of Curve25519 without any transforms performed for EC points.
@@ -23,7 +23,10 @@ use crate::group::{ElementOps, Group, RandomBytesProvider, ScalarOps};
 /// [`Ristretto`]: crate::group::Ristretto
 /// [pitfalls]: https://ristretto.group/why_ristretto.html#pitfalls-of-a-cofactor
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(docsrs, doc(cfg(feature = "curve25519-dalek")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "curve25519-dalek", feature = "curve25519-dalek-ng")))
+)]
 pub struct Curve25519Subgroup(());
 
 impl ScalarOps for Curve25519Subgroup {
@@ -129,11 +132,13 @@ impl Group for Curve25519Subgroup {
 
 #[cfg(test)]
 mod tests {
-    use curve25519_dalek::{constants::EIGHT_TORSION, scalar::Scalar, traits::Identity};
     use rand::thread_rng;
 
     use super::*;
-    use crate::PublicKeyConversionError;
+    use crate::{
+        curve25519::{constants::EIGHT_TORSION, scalar::Scalar, traits::Identity},
+        PublicKeyConversionError,
+    };
 
     type PublicKey = crate::PublicKey<Curve25519Subgroup>;
 

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -15,19 +15,18 @@
 use merlin::Transcript;
 use rand_chacha::ChaChaRng;
 use rand_core::{CryptoRng, RngCore, SeedableRng};
-use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroize;
 
 use core::{fmt, ops, str};
 
-#[cfg(feature = "curve25519-dalek")]
+#[cfg(any(feature = "curve25519-dalek", feature = "curve25519-dalek-ng"))]
 mod curve25519;
 mod generic;
-#[cfg(feature = "curve25519-dalek")]
+#[cfg(any(feature = "curve25519-dalek", feature = "curve25519-dalek-ng"))]
 mod ristretto;
 
 pub use self::generic::Generic;
-#[cfg(feature = "curve25519-dalek")]
+#[cfg(any(feature = "curve25519-dalek", feature = "curve25519-dalek-ng"))]
 pub use self::{curve25519::Curve25519Subgroup, ristretto::Ristretto};
 
 /// Provides an arbitrary number of random bytes.
@@ -74,8 +73,7 @@ pub trait ScalarOps {
         + ops::Sub<Output = Self::Scalar>
         + ops::Mul<Output = Self::Scalar>
         + for<'a> ops::Mul<&'a Self::Scalar, Output = Self::Scalar>
-        + ConditionallySelectable
-        + ConstantTimeEq
+        + PartialEq
         + Zeroize
         + fmt::Debug;
 
@@ -137,8 +135,7 @@ pub trait ElementOps: ScalarOps {
         + ops::Sub<Output = Self::Element>
         + ops::Neg<Output = Self::Element>
         + for<'a> ops::Mul<&'a Self::Scalar, Output = Self::Element>
-        + ConditionallySelectable
-        + ConstantTimeEq
+        + PartialEq
         + fmt::Debug;
 
     /// Byte size of a serialized [`Self::Element`].

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -1,18 +1,21 @@
-use curve25519_dalek::{
+use rand_core::{CryptoRng, RngCore};
+
+use core::convert::TryInto;
+
+use crate::curve25519::{
     constants::{RISTRETTO_BASEPOINT_POINT, RISTRETTO_BASEPOINT_TABLE},
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
     traits::{Identity, IsIdentity, MultiscalarMul, VartimeMultiscalarMul},
 };
-use rand_core::{CryptoRng, RngCore};
-
-use core::convert::TryInto;
-
 use crate::group::{ElementOps, Group, RandomBytesProvider, ScalarOps};
 
 /// [Ristretto](https://ristretto.group/) transform of Curve25519.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(docsrs, doc(cfg(feature = "curve25519-dalek")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "curve25519-dalek", feature = "curve25519-dalek-ng")))
+)]
 pub struct Ristretto(());
 
 impl ScalarOps for Ristretto {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -10,7 +10,7 @@ use crate::curve25519::{
 };
 use crate::group::{ElementOps, Group, RandomBytesProvider, ScalarOps};
 
-/// [Ristretto](https://ristretto.group/) transform of Curve25519.
+/// [Ristretto](https://ristretto.group/) transform of Curve25519, also known as ristretto255.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     docsrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,9 @@ pub use crate::{
     encryption::{Ciphertext, CiphertextWithValue, DiscreteLogTable},
     keys::{Keypair, PublicKey, PublicKeyConversionError, SecretKey},
     proofs::{
-        LogEqualityProof, PreparedRange, ProofOfPossession, RangeDecomposition, RangeProof,
-        RingProof, RingProofBuilder, SumOfSquaresProof, VerificationError,
+        CommitmentEquivalenceProof, LogEqualityProof, PreparedRange,
+        ProofOfPossession, RangeDecomposition, RangeProof, RingProof, RingProofBuilder,
+        SumOfSquaresProof, VerificationError,
     },
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //!   protocols, e.g., re-encryption.
 //! - Zero-knowledge range proofs for ElGamal ciphertexts are provided via [`RangeProof`]s
 //!   and a high-level [`PublicKey` method](PublicKey::encrypt_range()).
+//! - Proof of equivalence between an ElGamal ciphertext and a Pedersen commitment
+//!   is available as [`CommitmentEquivalenceProof`].
 //! - [`sharing`](crate::sharing) module exposes a threshold encryption scheme based
 //!   on [Feldman's verifiable secret sharing][feldman-vss], including verifiable distributed
 //!   decryption.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,9 @@ pub use crate::{
     encryption::{Ciphertext, CiphertextWithValue, DiscreteLogTable},
     keys::{Keypair, PublicKey, PublicKeyConversionError, SecretKey},
     proofs::{
-        CommitmentEquivalenceProof, LogEqualityProof, PreparedRange,
-        ProofOfPossession, RangeDecomposition, RangeProof, RingProof, RingProofBuilder,
-        SumOfSquaresProof, VerificationError,
+        CommitmentEquivalenceProof, LogEqualityProof, PreparedRange, ProofOfPossession,
+        RangeDecomposition, RangeProof, RingProof, RingProofBuilder, SumOfSquaresProof,
+        VerificationError,
     },
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,7 @@
 //! [`group`](crate::group) module exposes a generic framework for plugging a [`Group`]
 //! implementation into crypto primitives. It also provides several implementations:
 //!
-//! - [`Ristretto`] and [`Curve25519Subgroup`] implementations based on Curve25519 using
-//!   [`curve25519-dalek`].
+//! - [`Ristretto`] and [`Curve25519Subgroup`] implementations based on Curve25519.
 //! - [`Generic`] implementation allowing to plug in any elliptic curve group conforming to
 //!   the traits specified by the [`elliptic-curve`] crate. For example,
 //!   the secp256k1 curve can be used via the [`k256`] crate.
@@ -59,8 +58,34 @@
 //!
 //! *(on by default)*
 //!
-//! Implements [`Group`] for two prime groups based on Curve25519: its prime subgroup,
-//! and the Ristretto transform of Curve25519.
+//! Implements [`Group`] for two prime groups based on Curve25519 using the [`curve25519-dalek`]
+//! crate: its prime subgroup, and the Ristretto transform of Curve25519 (aka ristretto255).
+//!
+//! By default, `u64_backend` is selected for the `curve25519-dalek` crate. (The crate does not
+//! compile unless *some* backend is selected.) You may opt out of this selection by specifying
+//! dependencies as follows:
+//!
+//! ```toml
+//! [dependencies.elastic-elgamal]
+//! version = "..."
+//! default-features = false
+//! features = ["std", "curve25519-dalek"]
+//!
+//! [dependencies.curve25519-dalek]
+//! version = "3"
+//! default-features = false
+//! features = ["u32_backend"] # or other backend
+//! ```
+//!
+//! ## `curve25519-dalek-ng`
+//!
+//! *(off by default)*
+//!
+//! Same in terms of functionality as `curve25519-dalek`, but uses the [`curve25519-dalek-ng`]
+//! crate instead of [`curve25519-dalek`]. This may be beneficial for applications that use
+//! [`bulletproofs`] or other libraries depending on `curve25519-dalek-ng`.
+//!
+//! This feature is mutually exclusive with `curve25519-dalek`.
 //!
 //! ## `serde`
 //!
@@ -91,6 +116,8 @@
 //! [`Ristretto`]: crate::group::Ristretto
 //! [`Curve25519Subgroup`]: crate::group::Curve25519Subgroup
 //! [`curve25519-dalek`]: https://docs.rs/curve25519-dalek/
+//! [`curve25519-dalek-ng`]: https://docs.rs/curve25519-dalek-ng/
+//! [`bulletproofs`]: https://docs.rs/bulletproofs/
 //! [`Generic`]: crate::group::Generic
 //! [`elliptic-curve`]: https://docs.rs/elliptic-curve/
 //! [`k256`]: https://docs.rs/k256/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,18 @@ mod alloc {
     pub use std::collections::HashMap;
 }
 
+// Polyfill for Curve25519 types.
+#[cfg(any(feature = "curve25519-dalek-ng", feature = "curve25519-dalek"))]
+mod curve25519 {
+    #[cfg(all(feature = "curve25519-dalek-ng", feature = "curve25519-dalek"))]
+    compile_error!("`curve25519-dalek-ng` and `curve25519-dalek` features are mutually exclusive");
+
+    #[cfg(feature = "curve25519-dalek")]
+    pub use curve25519_dalek::*;
+    #[cfg(feature = "curve25519-dalek-ng")]
+    pub use curve25519_dalek_ng::*;
+}
+
 mod sealed {
     pub trait Sealed {}
 }

--- a/src/proofs/commitment.rs
+++ b/src/proofs/commitment.rs
@@ -88,14 +88,8 @@ use crate::{
 /// let value = 424242_u64;
 /// let ciphertext = CiphertextWithValue::new(value, &receiver, &mut rng)
 ///     .generalize();
-/// // Create a Pedersen commitment of the same value.
+/// // Create a blinding factor for the Pedersen commitment of the same value.
 /// let blinding = SecretKey::generate(&mut rng);
-/// let commitment = Ristretto::multi_mul(
-///     [&value.into(), blinding.expose_scalar()],
-///     [Ristretto::generator(), blinding_base],
-/// );
-/// // Use `commitment` and `blinding` in other proofs...
-///
 /// let (proof, commitment) = CommitmentEquivalenceProof::new(
 ///     &ciphertext,
 ///     &receiver,
@@ -104,6 +98,8 @@ use crate::{
 ///     &mut Transcript::new(b"custom_proof"),
 ///     &mut rng,
 /// );
+/// // Use `commitment` and `blinding` in other proofs...
+///
 /// proof.verify(
 ///     &ciphertext.into(),
 ///     &receiver,

--- a/src/proofs/commitment.rs
+++ b/src/proofs/commitment.rs
@@ -1,0 +1,326 @@
+//! Zero-knowledge proof of ElGamal encryption and Pedersen commitment equivalence.
+
+use merlin::Transcript;
+use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "serde")]
+use crate::serde::ScalarHelper;
+use crate::{
+    group::Group,
+    proofs::{TranscriptForGroup, VerificationError},
+    Ciphertext, CiphertextWithValue, PublicKey, SecretKey,
+};
+
+/// Zero-knowledge proof that an ElGamal ciphertext encrypts the same value as a Pedersen
+/// commitment.
+///
+/// This proof can be used to switch from frameworks applicable to ElGamal ciphertexts, to ones
+/// applicable to Pedersen commitments (e.g., [Bulletproofs] for range proofs).
+///
+/// [Bulletproofs]: https://crypto.stanford.edu/bulletproofs/
+///
+/// # Construction
+///
+/// We want to prove in zero knowledge the knowledge of scalars `r_e`, `v`, `r_c` such as
+///
+/// ```text
+/// R = [r_e]G; B = [v]G + [r_e]K;
+/// // (R, B) is ElGamal ciphertext of `v` for public key `K`
+/// C = [v]G + [r_c]H;
+/// // C is Pedersen commitment to `v`
+/// ```
+///
+/// Here, we assume that the conventional group generator `G` is shared between encryption and
+/// commitment protocols.
+///
+/// An interactive version of the proof can be built as a sigma protocol:
+///
+/// 1. **Commitment.** The prover generates 3 random scalars `e_r`, `e_v` and `e_c` and commits
+///   to them via `E_r = [e_r]G`, `E_b = [e_v]G + [e_r]K`, and `E_c = [e_v]G + [e_c]H`.
+/// 2. **Challenge.** The verifier sends to the prover random scalar `c`.
+/// 3. **Response.** The prover computes the following scalars and sends them to the verifier.
+///
+/// ```text
+/// s_r = e_r + c * r_e;
+/// s_v = e_v + c * v;
+/// s_c = e_c + c * r_c;
+/// ```
+///
+/// The verification equations are
+///
+/// ```text
+/// [s_r]G ?= E_r + [c]R;
+/// [s_v]G + [s_r]K ?= E_b + [c]B;
+/// [s_v]G + [s_c]H ?= E_c + [c]C;
+/// ```
+///
+/// A non-interactive version of the proof is obtained by applying [Fiat–Shamir transform][fst].
+/// As with other proofs, it is more efficient to represent a proof as the challenge
+/// and responses (i.e., 4 scalars in total).
+///
+/// [fst]: https://en.wikipedia.org/wiki/Fiat%E2%80%93Shamir_heuristic
+///
+/// # Examples
+///
+/// ```
+/// # use elastic_elgamal::{
+/// #     group::{ElementOps, ScalarOps, Group, Ristretto},
+/// #     Keypair, SecretKey, CommitmentEquivalenceProof, CiphertextWithValue,
+/// # };
+/// # use merlin::Transcript;
+/// # use rand::thread_rng;
+/// #
+/// # const BLINDING_BASE: &[u8] = &[
+/// #     140, 146, 64, 180, 86, 169, 230, 220, 101, 195, 119, 161, 4,
+/// #     141, 116, 95, 148, 160, 140, 219, 127, 68, 203, 205, 123, 70,
+/// #     243, 64, 72, 135, 17, 52,
+/// # ];
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let blinding_base = // Blinding base for Pedersen commitments
+///                     // (e.g., from Bulletproofs)
+/// #    Ristretto::deserialize_element(BLINDING_BASE).unwrap();
+/// let mut rng = thread_rng();
+/// let (receiver, _) = Keypair::<Ristretto>::generate(&mut rng).into_tuple();
+///
+/// // Create an ElGamal ciphertext of `value` for `receiver`.
+/// let value = 424242_u64;
+/// let ciphertext = CiphertextWithValue::new(value, &receiver, &mut rng)
+///     .generalize();
+/// // Create a Pedersen commitment of the same value.
+/// let blinding = SecretKey::generate(&mut rng);
+/// let commitment = Ristretto::multi_mul(
+///     [&value.into(), blinding.expose_scalar()],
+///     [Ristretto::generator(), blinding_base],
+/// );
+/// // Use `commitment` and `blinding` in other proofs...
+///
+/// let (proof, commitment) = CommitmentEquivalenceProof::new(
+///     &ciphertext,
+///     &receiver,
+///     &blinding,
+///     blinding_base,
+///     &mut Transcript::new(b"custom_proof"),
+///     &mut rng,
+/// );
+/// proof.verify(
+///     &ciphertext.into(),
+///     &receiver,
+///     commitment,
+///     blinding_base,
+///     &mut Transcript::new(b"custom_proof"),
+/// )?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+pub struct CommitmentEquivalenceProof<G: Group> {
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
+    challenge: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
+    randomness_response: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
+    value_response: G::Scalar,
+    #[cfg_attr(feature = "serde", serde(with = "ScalarHelper::<G>"))]
+    commitment_response: G::Scalar,
+}
+
+impl<G: Group> CommitmentEquivalenceProof<G> {
+    /// Creates a proof based on the `ciphertext` for `receiver` and `commitment_blinding`
+    /// with `commitment_blinding_base` for a Pedersen commitment. (The latter two args
+    /// correspond to `r_c` and `H` in the [*Construction*](#construction) section, respectively.)
+    ///
+    /// # Return value
+    ///
+    /// Returns a proof together with the Pedersen commitment.
+    pub fn new<R: RngCore + CryptoRng>(
+        ciphertext: &CiphertextWithValue<G>,
+        receiver: &PublicKey<G>,
+        commitment_blinding: &SecretKey<G>,
+        commitment_blinding_base: G::Element,
+        transcript: &mut Transcript,
+        rng: &mut R,
+    ) -> (Self, G::Element) {
+        let commitment = G::multi_mul(
+            [ciphertext.value(), commitment_blinding.expose_scalar()],
+            [G::generator(), commitment_blinding_base],
+        );
+
+        transcript.start_proof(b"commitment_equivalence");
+        transcript.append_element_bytes(b"K", receiver.as_bytes());
+        transcript.append_element::<G>(b"R", &ciphertext.inner().random_element);
+        transcript.append_element::<G>(b"B", &ciphertext.inner().blinded_element);
+        transcript.append_element::<G>(b"C", &commitment);
+
+        let random_scalar = SecretKey::<G>::generate(rng);
+        let value_scalar = SecretKey::<G>::generate(rng);
+        let commitment_scalar = SecretKey::<G>::generate(rng);
+        let random_commitment = G::mul_generator(random_scalar.expose_scalar());
+        transcript.append_element::<G>(b"[e_r]G", &random_commitment);
+
+        let value_element = G::mul_generator(value_scalar.expose_scalar());
+        let enc_blinding_commitment =
+            value_element + receiver.as_element() * random_scalar.expose_scalar();
+        transcript.append_element::<G>(b"[e_v]G + [e_r]K", &enc_blinding_commitment);
+        let commitment_commitment =
+            value_element + commitment_blinding_base * commitment_scalar.expose_scalar();
+        transcript.append_element::<G>(b"[e_v]G + [e_c]H", &commitment_commitment);
+
+        let challenge = transcript.challenge_scalar::<G>(b"c");
+        let randomness_response =
+            challenge * ciphertext.randomness().expose_scalar() + random_scalar.expose_scalar();
+        let value_response = challenge * ciphertext.value() + value_scalar.expose_scalar();
+        let commitment_response =
+            challenge * commitment_blinding.expose_scalar() + commitment_scalar.expose_scalar();
+
+        let proof = Self {
+            challenge,
+            randomness_response,
+            value_response,
+            commitment_response,
+        };
+        (proof, commitment)
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if this proof does not verify.
+    pub fn verify(
+        &self,
+        ciphertext: &Ciphertext<G>,
+        receiver: &PublicKey<G>,
+        commitment: G::Element,
+        commitment_blinding_base: G::Element,
+        transcript: &mut Transcript,
+    ) -> Result<(), VerificationError> {
+        transcript.start_proof(b"commitment_equivalence");
+        transcript.append_element_bytes(b"K", receiver.as_bytes());
+        transcript.append_element::<G>(b"R", &ciphertext.random_element);
+        transcript.append_element::<G>(b"B", &ciphertext.blinded_element);
+        transcript.append_element::<G>(b"C", &commitment);
+
+        let neg_challenge = -self.challenge;
+        let random_commitment = G::vartime_double_mul_generator(
+            &neg_challenge,
+            ciphertext.random_element,
+            &self.randomness_response,
+        );
+        transcript.append_element::<G>(b"[e_r]G", &random_commitment);
+
+        let enc_blinding_commitment = G::vartime_multi_mul(
+            [
+                &self.value_response,
+                &self.randomness_response,
+                &neg_challenge,
+            ],
+            [
+                G::generator(),
+                receiver.as_element(),
+                ciphertext.blinded_element,
+            ],
+        );
+        transcript.append_element::<G>(b"[e_v]G + [e_r]K", &enc_blinding_commitment);
+
+        let commitment_commitment = G::vartime_multi_mul(
+            [
+                &self.value_response,
+                &self.commitment_response,
+                &neg_challenge,
+            ],
+            [G::generator(), commitment_blinding_base, commitment],
+        );
+        transcript.append_element::<G>(b"[e_v]G + [e_c]H", &commitment_commitment);
+
+        let expected_challenge = transcript.challenge_scalar::<G>(b"c");
+        if expected_challenge == self.challenge {
+            Ok(())
+        } else {
+            Err(VerificationError::ChallengeMismatch)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "curve25519-dalek-ng"))]
+mod tests {
+    use super::*;
+    use crate::{
+        group::{ElementOps, Ristretto},
+        Keypair,
+    };
+
+    use bulletproofs::PedersenGens;
+    use rand::thread_rng;
+
+    #[test]
+    fn equivalence_proof_basics() {
+        let mut rng = thread_rng();
+        let (receiver, _) = Keypair::<Ristretto>::generate(&mut rng).into_tuple();
+        let value = 1234_u64;
+        let ciphertext = CiphertextWithValue::new(value, &receiver, &mut rng).generalize();
+
+        let commitment_gens = PedersenGens::default();
+        assert_eq!(commitment_gens.B, Ristretto::generator());
+        let blinding = SecretKey::generate(&mut rng);
+
+        let (proof, commitment) = CommitmentEquivalenceProof::new(
+            &ciphertext,
+            &receiver,
+            &blinding,
+            commitment_gens.B_blinding,
+            &mut Transcript::new(b"test"),
+            &mut rng,
+        );
+        assert_eq!(
+            commitment,
+            commitment_gens.commit(*ciphertext.value(), *blinding.expose_scalar())
+        );
+
+        let ciphertext = ciphertext.into();
+        proof
+            .verify(
+                &ciphertext,
+                &receiver,
+                commitment,
+                commitment_gens.B_blinding,
+                &mut Transcript::new(b"test"),
+            )
+            .unwrap();
+
+        let other_ciphertext = receiver.encrypt(8_u64, &mut rng);
+        let err = proof
+            .verify(
+                &other_ciphertext,
+                &receiver,
+                commitment,
+                commitment_gens.B_blinding,
+                &mut Transcript::new(b"test"),
+            )
+            .unwrap_err();
+        assert!(matches!(err, VerificationError::ChallengeMismatch));
+
+        let err = proof
+            .verify(
+                &ciphertext,
+                &receiver,
+                commitment + Ristretto::generator(),
+                commitment_gens.B_blinding,
+                &mut Transcript::new(b"test"),
+            )
+            .unwrap_err();
+        assert!(matches!(err, VerificationError::ChallengeMismatch));
+
+        let err = proof
+            .verify(
+                &ciphertext,
+                &receiver,
+                commitment,
+                commitment_gens.B_blinding,
+                &mut Transcript::new(b"other_test"),
+            )
+            .unwrap_err();
+        assert!(matches!(err, VerificationError::ChallengeMismatch));
+    }
+}

--- a/src/proofs/log_equality.rs
+++ b/src/proofs/log_equality.rs
@@ -4,7 +4,6 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use subtle::ConstantTimeEq;
 
 #[cfg(feature = "serde")]
 use crate::serde::ScalarHelper;
@@ -174,7 +173,7 @@ impl<G: Group> LogEqualityProof<G> {
         transcript.append_element::<G>(b"[x]K", &commitments.1);
         let expected_challenge = transcript.challenge_scalar::<G>(b"c");
 
-        if expected_challenge.ct_eq(&self.challenge).into() {
+        if expected_challenge == self.challenge {
             Ok(())
         } else {
             Err(VerificationError::ChallengeMismatch)

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     group::{Group, RandomBytesProvider},
 };
 
+mod commitment;
 mod log_equality;
 mod mul;
 mod possession;
@@ -16,6 +17,7 @@ mod range;
 mod ring;
 
 pub use self::{
+    commitment::CommitmentEquivalenceProof,
     log_equality::LogEqualityProof,
     mul::SumOfSquaresProof,
     possession::ProofOfPossession,

--- a/src/proofs/mul.rs
+++ b/src/proofs/mul.rs
@@ -4,7 +4,6 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use subtle::ConstantTimeEq;
 use zeroize::Zeroizing;
 
 use core::iter;
@@ -254,7 +253,7 @@ impl<G: Group> SumOfSquaresProof<G> {
         transcript.append_element::<G>(b"[e_x]X + [e_z]K", &value_sum_commitment);
         let expected_challenge = transcript.challenge_scalar::<G>(b"c");
 
-        if expected_challenge.ct_eq(&self.challenge).into() {
+        if expected_challenge == self.challenge {
             Ok(())
         } else {
             Err(VerificationError::ChallengeMismatch)

--- a/src/proofs/possession.rs
+++ b/src/proofs/possession.rs
@@ -4,7 +4,6 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use subtle::ConstantTimeEq;
 
 #[cfg(feature = "serde")]
 use crate::serde::{ScalarHelper, VecHelper};
@@ -157,7 +156,7 @@ impl<G: Group> ProofOfPossession<G> {
         }
 
         let expected_challenge = transcript.challenge_scalar::<G>(b"c");
-        if expected_challenge.ct_eq(&self.challenge).into() {
+        if expected_challenge == self.challenge {
             Ok(())
         } else {
             Err(VerificationError::ChallengeMismatch)

--- a/src/sharing/key_set.rs
+++ b/src/sharing/key_set.rs
@@ -3,7 +3,6 @@
 use merlin::Transcript;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use subtle::ConstantTimeEq;
 
 use core::{iter, ops};
 
@@ -181,7 +180,7 @@ impl<G: Group> PublicKeySet<G> {
 
             let interpolated_key = G::vartime_multi_mul(&key_denominators, starting_keys.clone());
             let interpolated_key = interpolated_key * &key_scale;
-            if !bool::from(interpolated_key.ct_eq(&key.as_element())) {
+            if interpolated_key != key.as_element() {
                 return Err(Error::MalformedParticipantKeys);
             }
         }

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -284,10 +284,8 @@ impl Params {
 
 #[cfg(test)]
 mod tests {
-    use curve25519_dalek::scalar::Scalar as Scalar25519;
-
     use super::*;
-    use crate::group::Ristretto;
+    use crate::{curve25519::scalar::Scalar as Scalar25519, group::Ristretto};
 
     #[test]
     fn lagrange_coeffs_are_computed_correctly() {

--- a/src/sharing/participant.rs
+++ b/src/sharing/participant.rs
@@ -7,7 +7,6 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use subtle::ConstantTimeEq;
 
 use core::iter;
 
@@ -113,8 +112,7 @@ impl<G: Group> ActiveParticipant<G> {
         secret_share: SecretKey<G>,
     ) -> Result<Self, Error> {
         let expected_element = key_set.participant_keys()[index].as_element();
-        let valid_share = G::mul_generator(secret_share.expose_scalar()).ct_eq(&expected_element);
-        if bool::from(valid_share) {
+        if G::mul_generator(secret_share.expose_scalar()) == expected_element {
             Ok(Self {
                 key_set,
                 index,
@@ -190,11 +188,10 @@ impl<G: Group> ActiveParticipant<G> {
 
 #[cfg(test)]
 mod tests {
-    use curve25519_dalek::scalar::Scalar as Scalar25519;
     use rand::thread_rng;
 
     use super::*;
-    use crate::group::Ristretto;
+    use crate::{curve25519::scalar::Scalar as Scalar25519, group::Ristretto};
 
     #[test]
     fn shared_2_of_3_key() {

--- a/tests/integration/basic.rs
+++ b/tests/integration/basic.rs
@@ -5,7 +5,6 @@ use rand::{thread_rng, Rng};
 
 use std::collections::HashMap;
 
-use crate::assert_ct_eq;
 use elastic_elgamal::{
     app::{ChoiceParams, EncryptedChoice},
     group::Group,
@@ -20,7 +19,7 @@ fn test_encryption_roundtrip<G: Group>() {
     let ciphertext = keypair.public().encrypt(message, &mut rng);
     let decryption = keypair.secret().decrypt_to_element(ciphertext);
     let message = G::mul_generator(&G::Scalar::from(message));
-    assert_ct_eq(&decryption, &message);
+    assert_eq!(decryption, message);
 }
 
 fn test_zero_encryption_works<G: Group>() {
@@ -32,7 +31,7 @@ fn test_zero_encryption_works<G: Group>() {
         .verify_zero(zero_ciphertext, &proof)
         .unwrap();
     let decrypted = keypair.secret().decrypt_to_element(zero_ciphertext);
-    assert_ct_eq(&decrypted, &G::identity());
+    assert_eq!(decrypted, G::identity());
 
     // The proof should not verify for non-zero messages.
     let ciphertext = keypair.public().encrypt(123_u64, &mut rng);
@@ -89,16 +88,16 @@ fn test_bool_encryption_works<G: Group>() {
     let keypair = Keypair::<G>::generate(&mut rng);
 
     let (ciphertext, proof) = keypair.public().encrypt_bool(false, &mut rng);
-    assert_ct_eq(
-        &keypair.secret().decrypt_to_element(ciphertext),
-        &G::identity(),
+    assert_eq!(
+        keypair.secret().decrypt_to_element(ciphertext),
+        G::identity(),
     );
     keypair.public().verify_bool(ciphertext, &proof).unwrap();
 
     let (other_ciphertext, other_proof) = keypair.public().encrypt_bool(true, &mut rng);
-    assert_ct_eq(
-        &keypair.secret().decrypt_to_element(other_ciphertext),
-        &G::generator(),
+    assert_eq!(
+        keypair.secret().decrypt_to_element(other_ciphertext),
+        G::generator(),
     );
     keypair
         .public()
@@ -117,9 +116,9 @@ fn test_bool_encryption_works<G: Group>() {
 
     // ...even if the encryption is obtained from the "correct" value.
     let combined_ciphertext = ciphertext + other_ciphertext;
-    assert_ct_eq(
-        &keypair.secret().decrypt_to_element(combined_ciphertext),
-        &G::generator(),
+    assert_eq!(
+        keypair.secret().decrypt_to_element(combined_ciphertext),
+        G::generator(),
     );
     assert!(keypair
         .public()
@@ -162,7 +161,7 @@ fn test_encrypted_choice<G: Group>(options_count: usize) {
         } else {
             G::identity()
         };
-        assert_ct_eq(&sk.decrypt_to_element(ciphertext), &expected_plaintext);
+        assert_eq!(sk.decrypt_to_element(ciphertext), expected_plaintext);
     }
 }
 
@@ -181,7 +180,7 @@ fn test_encrypted_multi_choice<G: Group>(options_count: usize) {
         } else {
             G::identity()
         };
-        assert_ct_eq(&sk.decrypt_to_element(ciphertext), &expected_plaintext);
+        assert_eq!(sk.decrypt_to_element(ciphertext), expected_plaintext);
     }
 }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,17 +1,4 @@
 //! Generic tests independent of the `Group` implementation.
 
-use subtle::ConstantTimeEq;
-
-use std::fmt;
-
 mod basic;
 mod sharing;
-
-pub fn assert_ct_eq<T: ConstantTimeEq + fmt::Debug>(x: &T, y: &T) {
-    assert!(
-        bool::from(x.ct_eq(y)),
-        "Values are not equal: {:?}, {:?}",
-        x,
-        y
-    );
-}

--- a/tests/integration/sharing.rs
+++ b/tests/integration/sharing.rs
@@ -6,7 +6,6 @@ use rand::{
 };
 use rand_core::{CryptoRng, RngCore};
 
-use crate::assert_ct_eq;
 use elastic_elgamal::{
     app::{ChoiceParams, EncryptedChoice, QuadraticVotingBallot, QuadraticVotingParams},
     group::Group,
@@ -101,7 +100,7 @@ fn tiny_fuzz<G: Group>(params: Params) {
             let combined = params.combine_shares(chosen_shares).unwrap();
             let decrypted = combined.decrypt_to_element(encrypted);
 
-            assert_ct_eq(&decrypted, &G::vartime_mul_generator(&value));
+            assert_eq!(decrypted, G::vartime_mul_generator(&value));
         }
     }
 }

--- a/tests/snapshots/snapshots__commitment-equiv-proof-k256.snap
+++ b/tests/snapshots/snapshots__commitment-equiv-proof-k256.snap
@@ -1,0 +1,15 @@
+---
+source: tests/snapshots.rs
+assertion_line: 189
+expression: commitment_with_proof
+---
+ciphertext:
+  blinded_element: AnlDgrDKfjVwC2gZp-LoKHYR9GG_UFOYt3d8qQZwUmEU
+  random_element: AgQbzI7_NulX5AZav0Ty90yRPsu9APHrKvYGo03s3Dn_
+commitment: A6EmmnhLsZ1jBLCRax0Rb075Tlp33Xzhbo0S6_Dz6KlK
+proof:
+  challenge: hIkpBORFeMenC7kaonVc10xckm3hp32Gh-FYtGCLsSY
+  commitment_response: l_e2IMM5PnIGGZEZh72HI8h59ZiEgkv9z2PnOpMTn38
+  randomness_response: 8X6oldgfdXnYj2reoB6XcpzxLUDEGO-gmuWxa72ef3A
+  value_response: m9PyCaAJ3P6pUcsVgwGUVCpVHaiuovBQlGCRfOSEoEU
+

--- a/tests/snapshots/snapshots__commitment-equiv-proof-ristretto.snap
+++ b/tests/snapshots/snapshots__commitment-equiv-proof-ristretto.snap
@@ -1,0 +1,15 @@
+---
+source: tests/snapshots.rs
+assertion_line: 189
+expression: commitment_with_proof
+---
+ciphertext:
+  blinded_element: dtgjCjLgWM9p__dqKjLX2uO-wCYr9eFC89FYfFaGTDg
+  random_element: gugt6pqWT9lwtV7WdEdZsVSYTUe0VyNh2w_CzDMKHXQ
+commitment: lHT2a6AewHoET3a82RQJaML87eN2fwEH1yCjGA98JSY
+proof:
+  challenge: w5affnYGUR2u9Y4eXBCyakyQ8Oj681Aayx4FKBdlUQU
+  commitment_response: 1_kcEt4lNzvRirFPUGJORT8deIfo4iDdttAARqQkcwA
+  randomness_response: B_JEtu43XQMsTedgnA05WTKP4A6CYJW0gmN98wYcSQQ
+  value_response: zeBQjPE-8APdvci24pCLH3GBxn_kn7pRhxGFXy0WRwA
+


### PR DESCRIPTION
This PR adds a zero-knowledge proof of Pedersen commitment <-> ElGamal ciphertext equivalence (i.e., a proof that the encrypted and committed values are equal). This can be used to move from ciphertext-based proofs to commitment-based ones (e.g., Bulletproofs).