### PR TITLE
Add encryption of group elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "elastic-elgamal"
 version = "0.2.1"
-authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
+authors = [
+  "Alex Ostrovski <ostrovski.alex@gmail.com>",
+  "Jiří Gavenda <jirigavenda98@gmail.com>",
+]
 edition = "2021"
 rust-version = "1.57"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ optional = true
 bulletproofs = "4.0.0"
 criterion = "0.3.4"
 doc-comment = "0.3.3"
-insta = "1.8.0"
+insta = { version = "1.18.2", features = ["yaml"] }
 k256 = { version = "0.11", default-features = false, features = ["arithmetic"] }
 rand = "0.8.3"
 serde_json = "1.0"

--- a/src/keys/impls.rs
+++ b/src/keys/impls.rs
@@ -22,6 +22,15 @@ impl<G: Group> PublicKey<G> {
         ExtendedCiphertext::new(element, self, rng).inner
     }
 
+    /// Encrypts a group element
+    pub fn encrypt_element<R: CryptoRng + RngCore>(
+        &self, value:
+         G::Element,
+        rng: &mut R,
+    ) -> Ciphertext<G> {
+        ExtendedCiphertext::new(value, self, rng).inner
+    }
+
     /// Encrypts zero value and provides a zero-knowledge proof of encryption correctness.
     pub fn encrypt_zero<R>(&self, rng: &mut R) -> (Ciphertext<G>, LogEqualityProof<G>)
     where

--- a/src/keys/impls.rs
+++ b/src/keys/impls.rs
@@ -22,10 +22,10 @@ impl<G: Group> PublicKey<G> {
         ExtendedCiphertext::new(element, self, rng).inner
     }
 
-    /// Encrypts a group element
+    /// Encrypts a group element.
     pub fn encrypt_element<R: CryptoRng + RngCore>(
-        &self, value:
-         G::Element,
+        &self,
+        value: G::Element,
         rng: &mut R,
     ) -> Ciphertext<G> {
         ExtendedCiphertext::new(value, self, rng).inner

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -227,7 +227,7 @@ impl std::error::Error for Error {
 }
 
 /// Parameters of a threshold ElGamal encryption scheme.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Params {
     /// Total number of shares / participants.


### PR DESCRIPTION
I've added a public method for encrypting a group element since it's useful to have other options to encode scalar to the group element than multiplying the generator. 
~I've also added a method which takes decryption shares and cyphertext and combines them to obtain the encrypted element.~ 