### PR TITLE
Distributed key generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-elgamal"
-version = "0.2.2"
+version = "0.2.1"
 authors = [
   "Alex Ostrovski <ostrovski.alex@gmail.com>",
   "Jiří Gavenda <jirigavenda98@gmail.com>",
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 elliptic-curve = { version = "0.12.0", features = ["sec1"] }
 rand_core = { version = "0.6.2", default-features = false }
 zeroize = { version = "1.3.0", default-features = false, features = ["alloc"] }
-sha2 = "0.10.6"
+sha2 = { version = "0.10.6", default-features = false }
 
 # Enables `Serialize` / `Deserialize` implementation for most types in the crate.
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-elgamal"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "Alex Ostrovski <ostrovski.alex@gmail.com>",
   "Jiří Gavenda <jirigavenda98@gmail.com>",
@@ -27,6 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 elliptic-curve = { version = "0.12.0", features = ["sec1"] }
 rand_core = { version = "0.6.2", default-features = false }
 zeroize = { version = "1.3.0", default-features = false, features = ["alloc"] }
+sha2 = "0.10.6"
 
 # Enables `Serialize` / `Deserialize` implementation for most types in the crate.
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/src/app/choice.rs
+++ b/src/app/choice.rs
@@ -430,9 +430,7 @@ impl fmt::Display for ChoiceVerificationError {
         match self {
             Self::OptionsLenMismatch { expected, actual } => write!(
                 formatter,
-                "number of options in the ballot ({act}) differs from expected ({exp})",
-                act = actual,
-                exp = expected
+                "number of options in the ballot ({actual}) differs from expected ({expected})",
             ),
             Self::Sum(err) => write!(formatter, "cannot verify sum proof: {err}"),
             Self::Range(err) => write!(formatter, "cannot verify range proofs: {err}"),

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -272,11 +272,7 @@ impl<G: Group> ParticipantCollectingPolynomials<G> {
             params: self.params,
             index: self.index,
             dealer: self.dealer.clone(),
-            public_polynomials: self
-                .public_polynomials
-                .iter()
-                .filter_map(std::clone::Clone::clone)
-                .collect(),
+            public_polynomials: self.public_polynomials.iter().flatten().cloned().collect(),
             cumulated_share: self.dealer.secret_share_for_participant(self.index),
             cumulated_public_poly: PublicPolynomial::<G>(public_polynomial),
             shares_received,

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -1,0 +1,413 @@
+//! Committed Pedersen's distributed key generation.
+//!
+//! DKG allows to securely generate shared secret without a need for a trusted
+//! dealer.
+//!
+//! This implementation is based on [Pedersen's DKG], which was shown by [Gennaro et al.]
+//! to contain flaw allowing an adversary to bias distribution of the shared public key.
+//! We try to prevent this kind of possible attacks by forcing the parties to
+//! commit to their public key shares before receiving public shares from other
+//! parties.
+//!
+//! [Pedersen's DKG]: https://link.springer.com/content/pdf/10.1007/3-540-46416-6_47.pdf
+//! [Gennaro et al.]: https://link.springer.com/content/pdf/10.1007/3-540-48910-X_21.pdf
+
+use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use core::fmt;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    alloc::{vec, Vec},
+    group::Group,
+    proofs::ProofOfPossession,
+    sharing::Dealer,
+    sharing::{self, Params, PublicKeySet, PublicPolynomial},
+    PublicKey, SecretKey,
+};
+
+/// Errors that can occur during the secret sharing protocol.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Secret received from the party does not correspond to their commitment via
+    /// the public polynomial.
+    InvalidSecret,
+    /// Provided commitment does not correspond to the party's public key share.
+    InvalidCommitment,
+    /// Secret share for this participant was already provided.
+    DuplicitShare,
+    /// Secret shares from some parties are missing.
+    MissingShares,
+    /// Provided proof of possession or public polynomial is malformed.
+    MalformedParticipantProof(sharing::Error),
+    /// Public shares obtained from cumulated public polynomial are inconsistent
+    InconsistentPublicShares(sharing::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSecret => formatter.write_str(
+                "secret received from the party does not correspond to their commitment via \
+                public polynomial",
+            ),
+            Self::InvalidCommitment => formatter.write_str(
+                "public polynomial received from one of the parties does not correspond \
+                to their commitment",
+            ),
+            Self::DuplicitShare => {
+                formatter.write_str("secret share for this participant was already provided")
+            }
+            Self::MissingShares => {
+                formatter.write_str("secret shares from some parties are missing")
+            }
+            Self::MalformedParticipantProof(err) => {
+                write!(
+                    formatter,
+                    "provided proof of possession or public polynomial is malformed: {err}"
+                )
+            }
+            Self::InconsistentPublicShares(err) => {
+                write!(
+                    formatter,
+                    "public shares obtained from cumulated public polynomial are inconsistent: {err}"
+                )
+            }
+        }
+    }
+}
+
+/// Structure for collecting commitments of public share in committed Pedersen's
+/// distributed key generation.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+pub struct DkgCommitmentsCollector<G: Group> {
+    params: Params,
+    index: usize,
+    dealer: Dealer<G>,
+    commitments: Vec<Option<[u8; 32]>>,
+    decommitment: [u8; 32],
+}
+
+impl<G: Group> DkgCommitmentsCollector<G> {
+    /// Instantiates a distributed key generation participant.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater or equal to number of shares.
+    pub fn new<R: CryptoRng + RngCore>(params: Params, index: usize, rng: &mut R) -> Self {
+        assert!(index < params.shares);
+        let mut decommitment = [0u8; 32];
+        rng.fill_bytes(&mut decommitment);
+        Self {
+            params,
+            index,
+            dealer: Dealer::new(params, rng),
+            commitments: vec![None; params.shares],
+            decommitment,
+        }
+    }
+
+    /// Generates commitment of participant's share of a public key.
+    pub fn commitment(&mut self) -> [u8; 32] {
+        if let Some(c) = self.commitments[self.index] {
+            c
+        } else {
+            let (public_poly, _) = self.dealer.public_info();
+            let mut hasher = Sha256::new();
+            let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
+            G::serialize_element(&public_poly[0], &mut bytes);
+            hasher.update(&bytes);
+            hasher.update(self.decommitment);
+            let c = hasher.finalize().into();
+            self.commitments[self.index] = Some(c);
+            c
+        }
+    }
+
+    /// Inserts commitment from other participant with index `participant_index`.
+    pub fn insert_commitment(&mut self, participant_index: usize, commitment: [u8; 32]) {
+        self.commitments[participant_index] = Some(commitment);
+    }
+
+    /// Returns indices of parties whose commitments were not provided.
+    pub fn missing_commitments(&self) -> Vec<usize> {
+        self.commitments
+            .iter()
+            .enumerate()
+            .filter_map(|(i, x)| if x.is_none() { Some(i) } else { None })
+            .collect()
+    }
+
+    /// If all commiements were received returns DkgShareCollector
+    /// otherwise returns None.
+    pub fn finish_commitment_phase(&self) -> Option<DkgSharesCollector<G>> {
+        if !self.missing_commitments().is_empty() {
+            return None;
+        }
+
+        let mut shares_received = vec![false; self.params.shares];
+        shares_received[self.index] = true;
+        let (public_polynomial, _) = self.dealer.public_info();
+        Some(DkgSharesCollector {
+            params: self.params,
+            index: self.index,
+            dealer: self.dealer.clone(),
+            decommitment: self.decommitment,
+            commitments: self.commitments.iter().filter_map(|x| *x).collect(),
+            cumulated_share: self.dealer.secret_share_for_participant(self.index),
+            cumulated_public_poly: PublicPolynomial::<G>(public_polynomial),
+            shares_received,
+        })
+    }
+}
+
+/// Structure for collecting secret shares in committed Pedersen's distributed
+/// key generation.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+pub struct DkgSharesCollector<G: Group> {
+    params: Params,
+    index: usize,
+    dealer: Dealer<G>,
+    decommitment: [u8; 32],
+    commitments: Vec<[u8; 32]>,
+    cumulated_share: SecretKey<G>,
+    cumulated_public_poly: PublicPolynomial<G>,
+    shares_received: Vec<bool>,
+}
+
+impl<G: Group> DkgSharesCollector<G> {
+    /// Returns a secret share for a participant with the specified `participant_index`.
+    pub fn secret_share_for_participant(&self, participant_index: usize) -> SecretKey<G> {
+        self.dealer.secret_share_for_participant(participant_index)
+    }
+
+    /// Returns public participant information: participant's public polynomial,
+    /// proof of possession for the corresponding secret polynomial and decommitment.
+    pub fn public_info(&self) -> (Vec<G::Element>, ProofOfPossession<G>, [u8; 32]) {
+        let (public_polynomial, proof_of_possession) = self.dealer.public_info();
+        (
+            public_polynomial,
+            proof_of_possession.clone(),
+            self.decommitment,
+        )
+    }
+
+    /// Returns indices of parties whose shares were not provided.
+    pub fn missing_shares(&self) -> Vec<usize> {
+        self.shares_received
+            .iter()
+            .enumerate()
+            .filter_map(|(i, x)| if *x { None } else { Some(i) })
+            .collect()
+    }
+
+    /// Inserts secret share from participant with index `participant_index` and
+    /// checks if the share is valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if provided secret share doesn't lie on given public
+    /// polynomial or the polynomial doesn't correspond to the previous commitment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.index` is greater or equal to number of participants,
+    /// which should never happen, unless DkgSharesCollector got corrupted.
+    pub fn insert_secret_share(
+        &mut self,
+        participant_index: usize,
+        secret_share: SecretKey<G>,
+        public_polynomial: &[G::Element],
+        proof_of_possession: &ProofOfPossession<G>,
+        decommitment: &[u8; 32],
+    ) -> Result<(), Error> {
+        if self.shares_received[participant_index] {
+            return Err(Error::DuplicitShare);
+        }
+
+        // verifies proof of possession of secret polynomial
+        let keyset =
+            match PublicKeySet::new(self.params, public_polynomial.to_vec(), proof_of_possession) {
+                Ok(keyset) => keyset,
+                Err(error) => return Err(Error::MalformedParticipantProof(error)),
+            };
+
+        let public_share = keyset.participant_key(self.index).unwrap();
+        if public_share.as_element() != G::mul_generator(secret_share.expose_scalar()) {
+            // point corresponding to the received secret share doesn't lie
+            // on the public polynomial
+            return Err(Error::InvalidSecret);
+        }
+
+        let mut hasher = Sha256::new();
+        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
+        G::serialize_element(&public_polynomial[0], &mut bytes);
+        hasher.update(&bytes);
+        hasher.update(decommitment);
+        let c: [u8; 32] = hasher.finalize().into();
+
+        if self.commitments[participant_index] != c {
+            // provided commitment doesn't match the given public key share
+            return Err(Error::InvalidCommitment);
+        }
+
+        self.cumulated_public_poly += &PublicPolynomial::<G>(public_polynomial.to_vec());
+        self.cumulated_share += secret_share;
+        self.shares_received[participant_index] = true;
+        Ok(())
+    }
+
+    /// If all secret shares are collected, returns combined secret share and
+    /// PublicKeySet containing public keys of all participating parties.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if secret shares from some parties were not provided, or
+    /// PublicKeySet can not be created.
+    pub fn keys(&self) -> Result<(SecretKey<G>, PublicKeySet<G>), Error> {
+        if !self.shares_received.iter().all(|x| *x) {
+            return Err(Error::MissingShares);
+        }
+
+        let participant_keys = (0..self.params.shares)
+            .map(|idx| {
+                PublicKey::from_element(
+                    self.cumulated_public_poly.value_at((idx as u64 + 1).into()),
+                )
+            })
+            .collect();
+        let keyset = match PublicKeySet::from_participants(self.params, participant_keys) {
+            Ok(keyset) => keyset,
+            Err(error) => return Err(Error::InconsistentPublicShares(error)),
+        };
+        Ok((self.cumulated_share.clone(), keyset))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use super::*;
+    use crate::{
+        curve25519::scalar::Scalar as Scalar25519, group::Ristretto, sharing::ActiveParticipant,
+    };
+    #[test]
+    fn dkg_shared_2_of_3_key() {
+        let mut rng = thread_rng();
+        let params = Params::new(3, 2);
+
+        let mut commitments_alice = DkgCommitmentsCollector::<Ristretto>::new(params, 0, &mut rng);
+        let mut commitments_bob = DkgCommitmentsCollector::<Ristretto>::new(params, 1, &mut rng);
+        let mut commitments_carol = DkgCommitmentsCollector::<Ristretto>::new(params, 2, &mut rng);
+
+        let comm_a = commitments_alice.commitment();
+        let comm_b = commitments_bob.commitment();
+        let comm_c = commitments_carol.commitment();
+
+        assert!(commitments_alice.missing_commitments() == vec![1, 2]);
+        commitments_alice.insert_commitment(1, comm_b);
+        commitments_alice.insert_commitment(2, comm_c);
+        commitments_bob.insert_commitment(0, comm_a);
+        commitments_bob.insert_commitment(2, comm_c);
+        commitments_carol.insert_commitment(0, comm_a);
+        commitments_carol.insert_commitment(1, comm_b);
+
+        let mut dkg_alice = commitments_alice.finish_commitment_phase().unwrap();
+        let mut dkg_bob = commitments_bob.finish_commitment_phase().unwrap();
+        let mut dkg_carol = commitments_carol.finish_commitment_phase().unwrap();
+
+        let (public_poly_a, public_proof_a, decomm_a) = dkg_alice.public_info();
+        let (public_poly_b, public_proof_b, decomm_b) = dkg_bob.public_info();
+        let (public_poly_c, public_proof_c, decomm_c) = dkg_carol.public_info();
+
+        assert!(dkg_alice.missing_shares() == vec![1, 2]);
+        dkg_alice
+            .insert_secret_share(
+                1,
+                dkg_bob.secret_share_for_participant(0),
+                &public_poly_b,
+                &public_proof_b,
+                &decomm_b,
+            )
+            .unwrap();
+        dkg_alice
+            .insert_secret_share(
+                2,
+                dkg_carol.secret_share_for_participant(0),
+                &public_poly_c,
+                &public_proof_c,
+                &decomm_c,
+            )
+            .unwrap();
+        dkg_bob
+            .insert_secret_share(
+                0,
+                dkg_alice.secret_share_for_participant(1),
+                &public_poly_a,
+                &public_proof_a,
+                &decomm_a,
+            )
+            .unwrap();
+        dkg_bob
+            .insert_secret_share(
+                2,
+                dkg_carol.secret_share_for_participant(1),
+                &public_poly_c,
+                &public_proof_c,
+                &decomm_c,
+            )
+            .unwrap();
+        dkg_carol
+            .insert_secret_share(
+                0,
+                dkg_alice.secret_share_for_participant(2),
+                &public_poly_a,
+                &public_proof_a,
+                &decomm_a,
+            )
+            .unwrap();
+        dkg_carol
+            .insert_secret_share(
+                1,
+                dkg_bob.secret_share_for_participant(2),
+                &public_poly_b,
+                &public_proof_b,
+                &decomm_b,
+            )
+            .unwrap();
+
+        let (alice_share, _) = dkg_alice.keys().unwrap();
+
+        let (bob_share, _) = dkg_bob.keys().unwrap();
+
+        let (carol_share, key_set) = dkg_carol.keys().unwrap();
+
+        let alice = ActiveParticipant::new(key_set.clone(), 0, alice_share).unwrap();
+        let bob = ActiveParticipant::new(key_set.clone(), 1, bob_share).unwrap();
+        let _carol = ActiveParticipant::new(key_set.clone(), 2, carol_share).unwrap();
+
+        let ciphertext = key_set.shared_key().encrypt(15_u64, &mut rng);
+        let (alice_share, proof) = alice.decrypt_share(ciphertext, &mut rng);
+        key_set
+            .verify_share(alice_share.into(), ciphertext, 0, &proof)
+            .unwrap();
+
+        let (bob_share, proof) = bob.decrypt_share(ciphertext, &mut rng);
+        key_set
+            .verify_share(bob_share.into(), ciphertext, 1, &proof)
+            .unwrap();
+
+        let composite_dh_element =
+            *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
+        let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));
+        assert_eq!(composite_dh_element, ciphertext.blinded_element - message);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,9 @@ mod alloc {
     extern crate alloc;
 
     #[cfg(not(feature = "std"))]
-    pub use alloc::{string::ToString, vec, vec::Vec};
+    pub use alloc::{format, string::ToString, vec, vec::Vec};
     #[cfg(feature = "std")]
-    pub use std::{string::ToString, vec, vec::Vec};
+    pub use std::{format, string::ToString, vec, vec::Vec};
 
     #[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
     compile_error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@
 
 pub mod app;
 mod decryption;
+pub mod dkg;
 mod encryption;
 pub mod group;
 mod keys;

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -111,10 +111,7 @@ impl fmt::Display for VerificationError {
                 actual,
             } => write!(
                 formatter,
-                "number of {collection} ({act}) differs from expected ({exp})",
-                collection = collection,
-                act = actual,
-                exp = expected
+                "number of {collection} ({actual}) differs from expected ({expected})",
             ),
         }
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -11,7 +11,7 @@ use core::{fmt, marker::PhantomData};
 
 use crate::{
     alloc::{format, vec, ToString, Vec},
-    dkg::Decommitment,
+    dkg::Opening,
     group::Group,
     Keypair, PublicKey, SecretKey,
 };
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl Serialize for Decommitment {
+impl Serialize for Opening {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -88,7 +88,7 @@ impl Serialize for Decommitment {
     }
 }
 
-impl<'de> Deserialize<'de> for Decommitment {
+impl<'de> Deserialize<'de> for Opening {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -96,7 +96,7 @@ impl<'de> Deserialize<'de> for Decommitment {
         let bytes = deserialize_bytes(deserializer)?;
         let bytes_len = bytes.len();
         let message = format!("provided number of bytes is {bytes_len}, but expected is 32");
-        Ok(Decommitment(Zeroizing::new(
+        Ok(Opening(Zeroizing::new(
             bytes.try_into().map_err(|_| D::Error::custom(message))?,
         )))
     }
@@ -360,12 +360,12 @@ mod tests {
     use crate::group::Ristretto;
 
     #[test]
-    fn decommitment_roundtrip() {
-        let decommitment = Decommitment(Zeroizing::new([6; 32]));
-        let json = serde_json::to_value(&decommitment).unwrap();
+    fn opening_roundtrip() {
+        let opening = Opening(Zeroizing::new([6; 32]));
+        let json = serde_json::to_value(&opening).unwrap();
         assert!(json.is_string(), "{json:?}");
-        let decommitment_copy: Decommitment = serde_json::from_value(json).unwrap();
-        assert_eq!(decommitment_copy.0, decommitment.0);
+        let opening_copy: Opening = serde_json::from_value(json).unwrap();
+        assert_eq!(opening_copy.0, opening.0);
     }
 
     #[test]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -94,9 +94,11 @@ impl<'de> Deserialize<'de> for Decommitment {
         D: Deserializer<'de>,
     {
         let bytes = deserialize_bytes(deserializer)?;
-        Ok(Decommitment(Zeroizing::new(bytes.try_into().map_err(
-            |_| D::Error::custom("provided number of bytes is {bytes.len()}, but expected is 32"),
-        )?)))
+        let bytes_len = bytes.len();
+        let message = format!("provided number of bytes is {bytes_len}, but expected is 32");
+        Ok(Decommitment(Zeroizing::new(
+            bytes.try_into().map_err(|_| D::Error::custom(message))?,
+        )))
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroizing;
 use core::{fmt, marker::PhantomData};
 
 use crate::{
-    alloc::{vec, ToString, Vec},
+    alloc::{format, vec, ToString, Vec},
     dkg::Decommitment,
     group::Group,
     Keypair, PublicKey, SecretKey,

--- a/src/sharing/key_set.rs
+++ b/src/sharing/key_set.rs
@@ -2,75 +2,18 @@
 
 use merlin::Transcript;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
-use core::{iter, ops};
+use core::iter;
 
-use super::{lagrange_coefficients, Error, Params};
-#[cfg(feature = "serde")]
-use crate::serde::{ElementHelper, VecHelper};
+use super::{lagrange_coefficients, Error, Params, PublicPolynomial};
+
 use crate::{
     alloc::Vec,
     group::Group,
     proofs::{LogEqualityProof, ProofOfPossession, TranscriptForGroup, VerificationError},
     CandidateDecryption, Ciphertext, PublicKey, VerifiableDecryption,
 };
-
-#[derive(Debug, Clone)]
-struct PublicPolynomial<G: Group>(Vec<G::Element>);
-
-impl<G: Group> PublicPolynomial<G> {
-    fn value_at_zero(&self) -> G::Element {
-        self.0[0]
-    }
-
-    /// Computes value of this public polynomial at the specified point in variable time.
-    fn value_at(&self, x: G::Scalar) -> G::Element {
-        let mut val = G::Scalar::from(1_u64);
-        let scalars: Vec<_> = (0..self.0.len())
-            .map(|_| {
-                let output = val;
-                val = val * x;
-                output
-            })
-            .collect();
-
-        G::vartime_multi_mul(&scalars, self.0.iter().copied())
-    }
-}
-
-impl<G: Group> ops::AddAssign<&Self> for PublicPolynomial<G> {
-    fn add_assign(&mut self, rhs: &Self) {
-        debug_assert_eq!(
-            self.0.len(),
-            rhs.0.len(),
-            "cannot add polynomials of different degrees"
-        );
-        for (val, &rhs_val) in self.0.iter_mut().zip(&rhs.0) {
-            *val = *val + rhs_val;
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<G: Group> Serialize for PublicPolynomial<G> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        VecHelper::<ElementHelper<G>, 1>::serialize(&self.0, serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, G: Group> Deserialize<'de> for PublicPolynomial<G> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        VecHelper::<ElementHelper<G>, 1>::deserialize(deserializer).map(Self)
-    }
-}
 
 /// Full public information about the participants of a threshold ElGamal encryption scheme
 /// after all participants' commitments are collected.

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -127,7 +127,7 @@ mod participant;
 
 pub use self::{
     key_set::PublicKeySet,
-    participant::{ActiveParticipant, Dealer, DkgParticipant},
+    participant::{ActiveParticipant, Dealer},
 };
 
 /// Computes multipliers for the Lagrange polynomial interpolation based on the function value
@@ -173,8 +173,9 @@ fn lagrange_coefficients<G: Group>(indexes: &[usize]) -> (Vec<G::Scalar>, G::Sca
     (denominators, scale)
 }
 
+/// Structure representing public polynomial consisting of group elements.
 #[derive(Debug, Clone)]
-struct PublicPolynomial<G: Group>(Vec<G::Element>);
+pub struct PublicPolynomial<G: Group>(pub Vec<G::Element>);
 
 impl<G: Group> PublicPolynomial<G> {
     fn value_at_zero(&self) -> G::Element {
@@ -182,7 +183,7 @@ impl<G: Group> PublicPolynomial<G> {
     }
 
     /// Computes value of this public polynomial at the specified point in variable time.
-    fn value_at(&self, x: G::Scalar) -> G::Element {
+    pub fn value_at(&self, x: G::Scalar) -> G::Element {
         let mut val = G::Scalar::from(1_u64);
         let scalars: Vec<_> = (0..self.0.len())
             .map(|_| {
@@ -245,8 +246,6 @@ pub enum Error {
     ParticipantCountMismatch,
     /// Participants' public keys do not correspond to a single shared key.
     MalformedParticipantKeys,
-    /// Provided commitment does not correspond to the party's public key share.
-    InvalidCommitment,
 }
 
 impl fmt::Display for Error {
@@ -272,11 +271,6 @@ impl fmt::Display for Error {
             ),
             Self::MalformedParticipantKeys => formatter
                 .write_str("participants' public keys do not correspond to a single shared key"),
-
-            Self::InvalidCommitment => formatter.write_str(
-                "public polynomial received from one of the parties does not correspond \
-                to their commitment",
-            ),
         }
     }
 }

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -175,7 +175,7 @@ fn lagrange_coefficients<G: Group>(indexes: &[usize]) -> (Vec<G::Scalar>, G::Sca
 
 /// Structure representing public polynomial consisting of group elements.
 #[derive(Debug, Clone)]
-pub struct PublicPolynomial<G: Group>(pub Vec<G::Element>);
+pub(crate) struct PublicPolynomial<G: Group>(pub(crate) Vec<G::Element>);
 
 impl<G: Group> PublicPolynomial<G> {
     fn value_at_zero(&self) -> G::Element {
@@ -183,7 +183,7 @@ impl<G: Group> PublicPolynomial<G> {
     }
 
     /// Computes value of this public polynomial at the specified point in variable time.
-    pub fn value_at(&self, x: G::Scalar) -> G::Element {
+    pub(crate) fn value_at(&self, x: G::Scalar) -> G::Element {
         let mut val = G::Scalar::from(1_u64);
         let scalars: Vec<_> = (0..self.0.len())
             .map(|_| {

--- a/src/sharing/mod.rs
+++ b/src/sharing/mod.rs
@@ -113,7 +113,7 @@
 //! ```
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "serde")]
 use crate::serde::{ElementHelper, VecHelper};
@@ -175,7 +175,12 @@ fn lagrange_coefficients<G: Group>(indexes: &[usize]) -> (Vec<G::Scalar>, G::Sca
 
 /// Structure representing public polynomial consisting of group elements.
 #[derive(Debug, Clone)]
-pub(crate) struct PublicPolynomial<G: Group>(pub(crate) Vec<G::Element>);
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent, bound = ""))]
+pub(crate) struct PublicPolynomial<G: Group>(
+    #[cfg_attr(feature = "serde", serde(with = "VecHelper::<ElementHelper<G>, 1>"))]
+    pub(crate)  Vec<G::Element>,
+);
 
 impl<G: Group> PublicPolynomial<G> {
     fn value_at_zero(&self) -> G::Element {
@@ -207,26 +212,6 @@ impl<G: Group> ops::AddAssign<&Self> for PublicPolynomial<G> {
         for (val, &rhs_val) in self.0.iter_mut().zip(&rhs.0) {
             *val = *val + rhs_val;
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<G: Group> Serialize for PublicPolynomial<G> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        VecHelper::<ElementHelper<G>, 1>::serialize(&self.0, serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, G: Group> Deserialize<'de> for PublicPolynomial<G> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        VecHelper::<ElementHelper<G>, 1>::deserialize(deserializer).map(Self)
     }
 }
 

--- a/src/sharing/participant.rs
+++ b/src/sharing/participant.rs
@@ -9,12 +9,13 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use core::iter;
+use sha2::{Digest, Sha256};
 
 use crate::{
     alloc::Vec,
     group::Group,
     proofs::{LogEqualityProof, ProofOfPossession},
-    sharing::{Error, Params, PublicKeySet},
+    sharing::{Error, Params, PublicKeySet, PublicPolynomial},
     Ciphertext, Keypair, PublicKey, SecretKey, VerifiableDecryption,
 };
 
@@ -80,6 +81,131 @@ impl<G: Group> Dealer<G> {
             poly_value = poly_value * &power + keypair.secret().clone();
         }
         poly_value
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+/// Participant in committed Pedersen's distributed key generation.
+/// https://link.springer.com/content/pdf/10.1007/3-540-46416-6_47.pdf
+pub struct DkgParticipant<G: Group> {
+    params: Params,
+    index: usize,
+    dealer: Dealer<G>,
+    commitments: Option<Vec<Vec<u8>>>,
+}
+
+impl<G: Group> DkgParticipant<G> {
+    /// Instantiates a distributed key generation participant.
+    pub fn new<R: CryptoRng + RngCore>(params: Params, index: usize, rng: &mut R) -> Self {
+        Self {
+            params,
+            index,
+            dealer: Dealer::new(params, rng),
+            commitments: None,
+        }
+    }
+
+    /// Generates commitment of participant's share of a public key.
+    pub fn commitment(&mut self) -> Vec<u8> {
+        let (public_poly, _) = self.dealer.public_info();
+        let mut hasher = Sha256::new();
+        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
+        G::serialize_element(&public_poly[0], &mut bytes);
+        hasher.update(bytes);
+        hasher.finalize().to_vec()
+    }
+
+    /// Add commitments from other participants.
+    ///
+    /// # Panics
+    ///
+    /// Panics if number of `commitments` does not correspond with the number
+    /// of counterparties.
+    pub fn add_commitments(&mut self, commitments: Vec<Vec<u8>>) {
+        assert!(commitments.len() == self.params.shares - 1);
+        self.commitments = Some(commitments);
+    }
+
+    /// Returns a secret share for a participant with the specified `index`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.commitments` is None.
+    pub fn secret_share_for_participant(&self, index: usize) -> SecretKey<G> {
+        assert!(self.commitments.is_some());
+        self.dealer.secret_share_for_participant(index)
+    }
+
+    /// Returns public participant information: participant's public polynomial
+    /// and proof of possession for the corresponding secret polynomial.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.commitments` is None.
+    pub fn public_info(&self) -> (Vec<G::Element>, &ProofOfPossession<G>) {
+        assert!(self.commitments.is_some());
+        let (public_polynomial, proof_of_possession) = self.dealer.public_info();
+        (public_polynomial, proof_of_possession)
+    }
+
+    /// Combines partial secret shares and checks if all participants behaved
+    /// as expected.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if provided secret share doesn't lie on given public
+    /// polynomial or the polynomial doesn't correspond to the previous commitment.
+    ///
+    pub fn combine_secret_shares(
+        &self,
+        secret_shares: &[SecretKey<G>],
+        public_polynomials: &[&Vec<G::Element>],
+        proofs_of_possession: &[&ProofOfPossession<G>],
+    ) -> Result<(SecretKey<G>, PublicKeySet<G>), Error> {
+        let mut secret_share: SecretKey<G> = self.dealer.secret_share_for_participant(self.index);
+        let mut combined_public_poly = PublicPolynomial::<G>(self.dealer.public_info().0);
+
+        for i in 0..(self.params.shares - 1) {
+            // verifies proof of possession of secret polynomial
+            let keyset = PublicKeySet::new(
+                self.params,
+                public_polynomials[i].clone(),
+                proofs_of_possession[i],
+            )?;
+
+            if !matches!(keyset.participant_key(self.index), Some(pk) if
+            pk.as_element() == G::mul_generator(secret_shares[i].clone().expose_scalar()))
+            {
+                // point corresponding to the received secret share doesn't lie
+                // on the public polynomial
+                return Err(Error::InvalidSecret);
+            }
+
+            combined_public_poly += &PublicPolynomial::<G>(public_polynomials[i].clone());
+
+            secret_share += secret_shares[i].clone();
+
+            let mut hasher = Sha256::new();
+            let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
+            G::serialize_element(&public_polynomials[i][0], &mut bytes);
+            hasher.update(bytes);
+            let c = hasher.finalize().to_vec();
+
+            if !matches!(self.commitments.clone(), Some(cs) if cs[i] == c) {
+                // provided commitment doesn't match the given public key share
+                return Err(Error::InvalidCommitment);
+            }
+        }
+
+        let participant_keys = (0..self.params.shares)
+            .map(|idx| {
+                PublicKey::from_element(combined_public_poly.value_at((idx as u64 + 1).into()))
+            })
+            .collect();
+        let keyset = PublicKeySet::from_participants(self.params, participant_keys)?;
+        Ok((secret_share, keyset))
     }
 }
 
@@ -236,6 +362,81 @@ mod tests {
         // We need to find `a0` from the following equations:
         // a0 +   a1 = alice_share.dh_element;
         // a0 + 2*a1 = bob_share.dh_element;
+        let composite_dh_element =
+            *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
+        let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));
+        assert_eq!(composite_dh_element, ciphertext.blinded_element - message);
+    }
+
+    #[test]
+    fn dkg_shared_2_of_3_key() {
+        let mut rng = thread_rng();
+        let params = Params::new(3, 2);
+
+        let mut dkg_alice = DkgParticipant::<Ristretto>::new(params, 0, &mut rng);
+        let mut dkg_bob = DkgParticipant::<Ristretto>::new(params, 1, &mut rng);
+        let mut dkg_carol = DkgParticipant::<Ristretto>::new(params, 2, &mut rng);
+
+        let comm_a = dkg_alice.commitment();
+        let comm_b = dkg_bob.commitment();
+        let comm_c = dkg_carol.commitment();
+
+        dkg_alice.add_commitments(vec![comm_b.clone(), comm_c.clone()]);
+        dkg_bob.add_commitments(vec![comm_a.clone(), comm_c]);
+        dkg_carol.add_commitments(vec![comm_a, comm_b]);
+
+        let (public_poly_a, public_proof_a) = dkg_alice.public_info();
+        let (public_poly_b, public_proof_b) = dkg_bob.public_info();
+        let (public_poly_c, public_proof_c) = dkg_carol.public_info();
+
+        let (alice_share, _) = dkg_alice
+            .combine_secret_shares(
+                &[
+                    dkg_bob.secret_share_for_participant(0),
+                    dkg_carol.secret_share_for_participant(0),
+                ],
+                &[&public_poly_b, &public_poly_c],
+                &[public_proof_b, public_proof_c],
+            )
+            .unwrap();
+
+        let (bob_share, _) = dkg_bob
+            .combine_secret_shares(
+                &[
+                    dkg_alice.secret_share_for_participant(1),
+                    dkg_carol.secret_share_for_participant(1),
+                ],
+                &[&public_poly_a, &public_poly_c],
+                &[public_proof_a, public_proof_c],
+            )
+            .unwrap();
+
+        let (carol_share, key_set) = dkg_carol
+            .combine_secret_shares(
+                &[
+                    dkg_alice.secret_share_for_participant(2),
+                    dkg_bob.secret_share_for_participant(2),
+                ],
+                &[&public_poly_a, &public_poly_b],
+                &[public_proof_a, public_proof_b],
+            )
+            .unwrap();
+
+        let alice = ActiveParticipant::new(key_set.clone(), 0, alice_share).unwrap();
+        let bob = ActiveParticipant::new(key_set.clone(), 1, bob_share).unwrap();
+        let _carol = ActiveParticipant::new(key_set.clone(), 2, carol_share).unwrap();
+
+        let ciphertext = key_set.shared_key().encrypt(15_u64, &mut rng);
+        let (alice_share, proof) = alice.decrypt_share(ciphertext, &mut rng);
+        key_set
+            .verify_share(alice_share.into(), ciphertext, 0, &proof)
+            .unwrap();
+
+        let (bob_share, proof) = bob.decrypt_share(ciphertext, &mut rng);
+        key_set
+            .verify_share(bob_share.into(), ciphertext, 1, &proof)
+            .unwrap();
+
         let composite_dh_element =
             *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
         let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));

--- a/src/sharing/participant.rs
+++ b/src/sharing/participant.rs
@@ -9,13 +9,12 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use core::iter;
-use sha2::{Digest, Sha256};
 
 use crate::{
     alloc::Vec,
     group::Group,
     proofs::{LogEqualityProof, ProofOfPossession},
-    sharing::{Error, Params, PublicKeySet, PublicPolynomial},
+    sharing::{Error, Params, PublicKeySet},
     Ciphertext, Keypair, PublicKey, SecretKey, VerifiableDecryption,
 };
 
@@ -80,131 +79,6 @@ impl<G: Group> Dealer<G> {
             poly_value = poly_value * &power + keypair.secret().clone();
         }
         poly_value
-    }
-}
-
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound = ""))]
-/// Participant in committed Pedersen's distributed key generation.
-/// https://link.springer.com/content/pdf/10.1007/3-540-46416-6_47.pdf
-pub struct DkgParticipant<G: Group> {
-    params: Params,
-    index: usize,
-    dealer: Dealer<G>,
-    commitments: Option<Vec<Vec<u8>>>,
-}
-
-impl<G: Group> DkgParticipant<G> {
-    /// Instantiates a distributed key generation participant.
-    pub fn new<R: CryptoRng + RngCore>(params: Params, index: usize, rng: &mut R) -> Self {
-        Self {
-            params,
-            index,
-            dealer: Dealer::new(params, rng),
-            commitments: None,
-        }
-    }
-
-    /// Generates commitment of participant's share of a public key.
-    pub fn commitment(&mut self) -> Vec<u8> {
-        let (public_poly, _) = self.dealer.public_info();
-        let mut hasher = Sha256::new();
-        let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
-        G::serialize_element(&public_poly[0], &mut bytes);
-        hasher.update(bytes);
-        hasher.finalize().to_vec()
-    }
-
-    /// Add commitments from other participants.
-    ///
-    /// # Panics
-    ///
-    /// Panics if number of `commitments` does not correspond with the number
-    /// of counterparties.
-    pub fn add_commitments(&mut self, commitments: Vec<Vec<u8>>) {
-        assert!(commitments.len() == self.params.shares - 1);
-        self.commitments = Some(commitments);
-    }
-
-    /// Returns a secret share for a participant with the specified `index`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self.commitments` is None.
-    pub fn secret_share_for_participant(&self, index: usize) -> SecretKey<G> {
-        assert!(self.commitments.is_some());
-        self.dealer.secret_share_for_participant(index)
-    }
-
-    /// Returns public participant information: participant's public polynomial
-    /// and proof of possession for the corresponding secret polynomial.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self.commitments` is None.
-    pub fn public_info(&self) -> (Vec<G::Element>, &ProofOfPossession<G>) {
-        assert!(self.commitments.is_some());
-        let (public_polynomial, proof_of_possession) = self.dealer.public_info();
-        (public_polynomial, proof_of_possession)
-    }
-
-    /// Combines partial secret shares and checks if all participants behaved
-    /// as expected.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if provided secret share doesn't lie on given public
-    /// polynomial or the polynomial doesn't correspond to the previous commitment.
-    ///
-    pub fn combine_secret_shares(
-        &self,
-        secret_shares: &[SecretKey<G>],
-        public_polynomials: &[&Vec<G::Element>],
-        proofs_of_possession: &[&ProofOfPossession<G>],
-    ) -> Result<(SecretKey<G>, PublicKeySet<G>), Error> {
-        let mut secret_share: SecretKey<G> = self.dealer.secret_share_for_participant(self.index);
-        let mut combined_public_poly = PublicPolynomial::<G>(self.dealer.public_info().0);
-
-        for i in 0..(self.params.shares - 1) {
-            // verifies proof of possession of secret polynomial
-            let keyset = PublicKeySet::new(
-                self.params,
-                public_polynomials[i].clone(),
-                proofs_of_possession[i],
-            )?;
-
-            if !matches!(keyset.participant_key(self.index), Some(pk) if
-            pk.as_element() == G::mul_generator(secret_shares[i].clone().expose_scalar()))
-            {
-                // point corresponding to the received secret share doesn't lie
-                // on the public polynomial
-                return Err(Error::InvalidSecret);
-            }
-
-            combined_public_poly += &PublicPolynomial::<G>(public_polynomials[i].clone());
-
-            secret_share += secret_shares[i].clone();
-
-            let mut hasher = Sha256::new();
-            let mut bytes = vec![0_u8; G::ELEMENT_SIZE];
-            G::serialize_element(&public_polynomials[i][0], &mut bytes);
-            hasher.update(bytes);
-            let c = hasher.finalize().to_vec();
-
-            if !matches!(self.commitments.clone(), Some(cs) if cs[i] == c) {
-                // provided commitment doesn't match the given public key share
-                return Err(Error::InvalidCommitment);
-            }
-        }
-
-        let participant_keys = (0..self.params.shares)
-            .map(|idx| {
-                PublicKey::from_element(combined_public_poly.value_at((idx as u64 + 1).into()))
-            })
-            .collect();
-        let keyset = PublicKeySet::from_participants(self.params, participant_keys)?;
-        Ok((secret_share, keyset))
     }
 }
 
@@ -361,81 +235,6 @@ mod tests {
         // We need to find `a0` from the following equations:
         // a0 +   a1 = alice_share.dh_element;
         // a0 + 2*a1 = bob_share.dh_element;
-        let composite_dh_element =
-            *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
-        let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));
-        assert_eq!(composite_dh_element, ciphertext.blinded_element - message);
-    }
-
-    #[test]
-    fn dkg_shared_2_of_3_key() {
-        let mut rng = thread_rng();
-        let params = Params::new(3, 2);
-
-        let mut dkg_alice = DkgParticipant::<Ristretto>::new(params, 0, &mut rng);
-        let mut dkg_bob = DkgParticipant::<Ristretto>::new(params, 1, &mut rng);
-        let mut dkg_carol = DkgParticipant::<Ristretto>::new(params, 2, &mut rng);
-
-        let comm_a = dkg_alice.commitment();
-        let comm_b = dkg_bob.commitment();
-        let comm_c = dkg_carol.commitment();
-
-        dkg_alice.add_commitments(vec![comm_b.clone(), comm_c.clone()]);
-        dkg_bob.add_commitments(vec![comm_a.clone(), comm_c]);
-        dkg_carol.add_commitments(vec![comm_a, comm_b]);
-
-        let (public_poly_a, public_proof_a) = dkg_alice.public_info();
-        let (public_poly_b, public_proof_b) = dkg_bob.public_info();
-        let (public_poly_c, public_proof_c) = dkg_carol.public_info();
-
-        let (alice_share, _) = dkg_alice
-            .combine_secret_shares(
-                &[
-                    dkg_bob.secret_share_for_participant(0),
-                    dkg_carol.secret_share_for_participant(0),
-                ],
-                &[&public_poly_b, &public_poly_c],
-                &[public_proof_b, public_proof_c],
-            )
-            .unwrap();
-
-        let (bob_share, _) = dkg_bob
-            .combine_secret_shares(
-                &[
-                    dkg_alice.secret_share_for_participant(1),
-                    dkg_carol.secret_share_for_participant(1),
-                ],
-                &[&public_poly_a, &public_poly_c],
-                &[public_proof_a, public_proof_c],
-            )
-            .unwrap();
-
-        let (carol_share, key_set) = dkg_carol
-            .combine_secret_shares(
-                &[
-                    dkg_alice.secret_share_for_participant(2),
-                    dkg_bob.secret_share_for_participant(2),
-                ],
-                &[&public_poly_a, &public_poly_b],
-                &[public_proof_a, public_proof_b],
-            )
-            .unwrap();
-
-        let alice = ActiveParticipant::new(key_set.clone(), 0, alice_share).unwrap();
-        let bob = ActiveParticipant::new(key_set.clone(), 1, bob_share).unwrap();
-        let _carol = ActiveParticipant::new(key_set.clone(), 2, carol_share).unwrap();
-
-        let ciphertext = key_set.shared_key().encrypt(15_u64, &mut rng);
-        let (alice_share, proof) = alice.decrypt_share(ciphertext, &mut rng);
-        key_set
-            .verify_share(alice_share.into(), ciphertext, 0, &proof)
-            .unwrap();
-
-        let (bob_share, proof) = bob.decrypt_share(ciphertext, &mut rng);
-        key_set
-            .verify_share(bob_share.into(), ciphertext, 1, &proof)
-            .unwrap();
-
         let composite_dh_element =
             *alice_share.as_element() * Scalar25519::from(2_u64) - *bob_share.as_element();
         let message = Ristretto::mul_generator(&Scalar25519::from(15_u64));


### PR DESCRIPTION
I've added structure and methods for distributed key generation based on Pedersen's distributed key generation (https://link.springer.com/content/pdf/10.1007/3-540-46416-6_47.pdf) with a commitment preventing malicious parties from creating bias in the resulting secret. 
I used hash (a particular implementation of SHA256) as a non-malleable trapdoor commitment, which seems to be against this library's "pluggable crypto backend" idea. So that's something I feel should be improved, but I'm not sure what is the best way to do it. 