### PR TITLE
Adding methods to create EncryptedChoice and Ciphertext

### DIFF
--- a/src/app/choice.rs
+++ b/src/app/choice.rs
@@ -406,7 +406,20 @@ impl<G: Group, S: ProveSum<G>> EncryptedChoice<G, S> {
     pub fn sum_proof(&self) -> &S::Proof {
         &self.sum_proof
     }
+
+
+    /// Returns a new encrypted choice
+    pub fn new_encrypted_choice(choices: Vec<Ciphertext<G>>, range_proof: RingProof<G>, sum_proof: S::Proof) -> Self {
+        Self {
+            choices,
+            range_proof,
+            sum_proof
+        }
+    }
+
 }
+
+
 
 /// Error verifying an [`EncryptedChoice`].
 #[derive(Debug)]

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -151,6 +151,14 @@ impl<G: Group> Ciphertext<G> {
         G::serialize_element(&self.blinded_element, &mut bytes[G::ELEMENT_SIZE..]);
         bytes
     }
+
+    pub fn new(random_element: G::Element, blinded_element: G::Element) -> Self {
+        Self {
+            random_element,
+            blinded_element
+        }
+    }
+
 }
 
 impl<G: Group> ops::Add for Ciphertext<G> {


### PR DESCRIPTION
We are using this library on one of our applications and we need a way to serialize and deserialize EncryptedChoice and Ciphertext, while the serialization and deserialization can be performed outside of the library, we need the feature to reconstruct these structures again in this library.