### PR TITLE
Implement Zeroize trait for SecretKey

### DIFF
--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -32,6 +32,12 @@ impl<G: Group> Clone for SecretKey<G> {
     }
 }
 
+impl<G: Group> Zeroize for SecretKey<G> {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 impl<G: Group> Drop for SecretKey<G> {
     fn drop(&mut self) {
         self.0.zeroize();


### PR DESCRIPTION
## What?

- Implement `Zeroize` for `SecretKey`

Open to implement other missing traits.

## Why?

Since `SecretKey` is a thin wrapper for a group scalar I think it makes sense to implement this trait.

I was using the `secrecy` crate to protect the key but it didn't implement `Zeroize`. It's useful to protect sensitive data by erasing from memory and also forbid logs of the secrets. I see this library takes care of both problems by itself. Nevertheless, someone might needs this for other reasons.

If that makes sense to you, are there other traits worth implementing?

```rs
type Scalar: Copy
        + Default
        + From<u64>
        + From<Self::Scalar> // `PublicKey::encrypt()` doesn't work without this
        + ops::Neg<Output = Self::Scalar>
        + ops::Add<Output = Self::Scalar>
        + for<'a> ops::Add<&'a Self::Scalar, Output = Self::Scalar>
        + ops::Sub<Output = Self::Scalar>
        + ops::Mul<Output = Self::Scalar>
        + for<'a> ops::Mul<&'a Self::Scalar, Output = Self::Scalar>
        + PartialEq
        + Zeroize
        + fmt::Debug;
```
