### PR TITLE
Implement Ciphertext::from_elements

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -112,6 +112,14 @@ impl<G: Group> fmt::Debug for Ciphertext<G> {
 }
 
 impl<G: Group> Ciphertext<G> {
+    /// Creates `Ciphertext` instance from `random_element` and `blinded_element`.
+    pub fn from_elements(random_element: G::Element, blinded_element: G::Element) -> Self {
+        Self {
+            random_element,
+            blinded_element,
+        }
+    }
+
     /// Represents encryption of zero value without the blinding factor.
     pub fn zero() -> Self {
         Self {


### PR DESCRIPTION
## What?

This is similar to [PR34](https://github.com/slowli/elastic-elgamal/pull/34). It implements additional function in `Ciphertext`. I've named it `from_elements` as there are already `from_element` functions in `PublicKey` and `VerifiableDecryption` (of course I can change to `from_parts` or any other name). For example it allows to instantiate Ciphertext from untagged bytes:

```rust
use elastic_elgamal::{group::Generic, Ciphertext};
use p256::{elliptic_curve::sec1::FromEncodedPoint, AffinePoint, EncodedPoint, NistP256};

fn main() {
    let random_element_bytes = [0u8; 64]; // some real bytes here
    let blinded_element_bytes = [0u8; 64]; // some real bytes here

    let random_element = EncodedPoint::from_untagged_bytes(&random_element_bytes.into());
    let random_element = AffinePoint::from_encoded_point(&random_element).unwrap();

    let blinded_element = EncodedPoint::from_untagged_bytes(&blinded_element_bytes.into());
    let blinded_element = AffinePoint::from_encoded_point(&blinded_element).unwrap();

    let ciphertext: Ciphertext<Generic<NistP256>> =
        Ciphertext::from_elements(random_element.into(), blinded_element.into());
}
```

<!-- Briefly describe changes in the PR. If there are several things, organize them as a list. -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- If applicable, attach related issue(s) -->

## Why?

[playready-rs](https://github.com/dobo90/playready-rs) requires a functionality to instantiate `Ciphertext` from bytes sent over the wire. For now I've forked `elastic-elgamal` but I would love to publish `playready-rs` on [crates.io](https://creates.io) (but it's not possible as it uses modified version of this repository).
